### PR TITLE
typo in route name

### DIFF
--- a/lib/foreman_openscap/engine.rb
+++ b/lib/foreman_openscap/engine.rb
@@ -46,7 +46,7 @@ module ForemanOpenscap
           permission :create_arf_reports, {'api/v2/compliance/arf_reports' => [:create]}
 
           permission :view_scaptimony_policies, {:scaptimony_policies         => [:index, :show, :parse, :auto_complete_search],
-                                                 :scaptimony_dashboard        => [:index],
+                                                 :scaptimony_policy_dashboard => [:index],
                                                  'api/v2/compliance/policies' => [:index, :show, :content]},
                      :resource_type => 'Scaptimony::Policy'
           permission :edit_scaptimony_policies, {:scaptimony_policies         => [:edit, :update, :scap_content_selected],


### PR DESCRIPTION
Typo is causing [tests](http://ci.theforeman.org/job/test_plugin_matrix/52/database=postgresql,ruby=2.1/testReport/junit/(root)/AccessPermissionsTest/test_0736_route_scaptimony_policy_dashboard_index_should_have_a_permission_that_grants_access/) to fail. 
Will merge on the spot, to ensure tests are passing