### PR TITLE
fixes #9950 - ensure scap content from file is created only once

### DIFF
--- a/lib/foreman_openscap/bulk_upload.rb
+++ b/lib/foreman_openscap/bulk_upload.rb
@@ -24,8 +24,9 @@ module ForemanOpenscap
         digest = Digest::SHA2.hexdigest(datastream)
         title = content_name(datastream)
         filename = original_filename(datastream)
-        scap_content = Scaptimony::ScapContent.where(:title => title, :digest => digest, :scap_file => file).first_or_initialize
+        scap_content = Scaptimony::ScapContent.where(:title => title, :digest => digest).first_or_initialize
         unless scap_content.persisted?
+          scap_content.scap_file = file
           scap_content.original_filename = filename
           next puts "## SCAP content is invalid: #{scap_content.errors.full_messages.uniq.join(',')} ##" unless scap_content.valid?
           if scap_content.save

--- a/test/lib/foreman_openscap/bulk_upload_test.rb
+++ b/test/lib/foreman_openscap/bulk_upload_test.rb
@@ -1,0 +1,16 @@
+require 'test_plugin_helper'
+
+class BulkUploadTest < ActiveSupport::TestCase
+  setup do
+    require 'foreman_openscap/bulk_upload'
+  end
+
+  test 'upload_from_files should create only one scap content' do
+    scap_files = ['../foreman_openscap/test/files/scap_contents/ssg-fedora-ds.xml']
+    assert_difference('Scaptimony::ScapContent.count', 1) do
+      2.times do
+        ForemanOpenscap::BulkUpload.new.upload_from_files(scap_files)
+      end
+    end
+  end
+end


### PR DESCRIPTION
@ares - this fixes when __same__ scap content is created (or usually fail) on each db:seed run