### PR TITLE
Fixes #11132 - Showing spinner until a report is loaded

### DIFF
--- a/app/assets/javascript/foreman_openscap/load_report.js
+++ b/app/assets/javascript/foreman_openscap/load_report.js
@@ -1,0 +1,6 @@
+$(document).ready(function() {
+    $('#frame').load(function() {
+        $('#loading').hide();
+        $('#frame').show().css('min-height', '800px');
+    });    
+});

--- a/app/views/scaptimony_arf_reports/show.html.erb
+++ b/app/views/scaptimony_arf_reports/show.html.erb
@@ -1,3 +1,12 @@
+<%= javascript 'foreman_openscap/load_report'%>
 <div class="row">
-  <iframe style="min-height: 800px" height="100%" width="100%" frameborder="0" src="<%= parse_scaptimony_arf_report_path(@arf_report) %>"></iframe>
+
+  <div id="loading">
+    <div class="col-md-4"></div>
+    <div class="col-md-4">
+      <%= image_tag('/assets/spinner.gif') %>
+      <%= _('Loading...') %>
+    </div>
+  </div>
+  <iframe id="frame" style="display: none" height="100%" width="100%" frameborder="0" src="<%= parse_scaptimony_arf_report_path(@arf_report) %>"></iframe>
 </div>


### PR DESCRIPTION
We wait for a report to fully load and we show a spinner in the meantime.