### PR TITLE
Fixes #11085 - Email reporting for openscap policies

### DIFF
--- a/app/mailers/foreman_openscap/policy_mailer.rb
+++ b/app/mailers/foreman_openscap/policy_mailer.rb
@@ -1,0 +1,42 @@
+module ForemanOpenscap
+  class PolicyMailer  < ::ApplicationMailer
+
+    def policy_summary(options = {})
+      set_url
+      user = ::User.find(options[:user])
+      @time = options[:time] || 1.day.ago
+
+      @policies = Scaptimony::Policy.all.reject {|policy| policy.assets.map(&:host).compact.empty?}
+      @compliant_hosts = @policies.map { |policy| Host.where(:id => policy.assets.comply_with(policy).map(&:assetable_id)) }.flatten
+      @incompliant_hosts = @policies.map { |policy| Host.where(:id => policy.assets.incomply_with(policy).map(&:assetable_id)) }.flatten
+      changed_hosts_of_policies(@policies)
+
+      if user.nil? || user.mail.nil?
+        logger.warn "User with valid email not supplied, mail report will not be sent"
+      else
+        set_locale_for(user) do
+          subject = _("Scap policies summary")
+          mail(:to => user.mail, :subject => subject)
+        end
+      end
+    end
+
+    private
+
+    def changed_hosts_of_policies(policies)
+      hash = @policies.inject({}) do |result, policy|
+        result[policy.id] = policy.hosts
+        result
+      end
+
+      @changed_hosts = []
+      hash.each do |key, values|
+        values.each do |host|
+          @changed_hosts << host if host.scap_status_changed?(Scaptimony::Policy.find key)
+        end
+      end
+      @changed_hosts.uniq
+    end
+
+  end
+end

--- a/app/models/concerns/foreman_openscap/arf_report_extensions.rb
+++ b/app/models/concerns/foreman_openscap/arf_report_extensions.rb
@@ -46,5 +46,13 @@ module ForemanOpenscap
     def passed?
       passed > 0 && !failed?
     end
+
+    def equal?(other)
+      results = [xccdf_rule_results, other.xccdf_rule_results].flatten.group_by(&:xccdf_rule_id).values
+      # for each rule, there should be one result from both reports
+      return false unless results.map(&:length).all? { |item| item == 2 }
+      results.map { |result| result.first.xccdf_result_id == result.last.xccdf_result_id }.all? && asset_id == other.asset_id && policy_id == other.policy_id
+    end
+
   end
 end

--- a/app/models/concerns/foreman_openscap/host_extensions.rb
+++ b/app/models/concerns/foreman_openscap/host_extensions.rb
@@ -30,6 +30,20 @@ module ForemanOpenscap
       combined.uniq
     end
 
+    def scap_status_changed?(policy)
+      last_reports = reports_for_policy(policy, 2)
+      return false if last_reports.length != 2
+      !last_reports.first.equal? last_reports.last
+    end
+
+    def reports_for_policy(policy, limit = nil)
+      if limit
+        Scaptimony::ArfReport.where(:asset_id => asset.id, :policy_id => policy.id).limit limit
+      else
+        Scaptimony::ArfReport.where(:asset_id => asset.id, :policy_id => policy.id)
+      end
+    end
+
     module ClassMethods
       def search_by_policy_name(key, operator, policy_name)
         cond = sanitize_sql_for_conditions(["scaptimony_policies.name #{operator} ?", value_to_sql(operator, policy_name)])

--- a/app/models/concerns/foreman_openscap/policy_extensions.rb
+++ b/app/models/concerns/foreman_openscap/policy_extensions.rb
@@ -66,6 +66,18 @@ module ForemanOpenscap
       hostgroup_ids = hostgroups.map(&:id).map(&:to_s)
     end
 
+    def host_ids
+      assets.where(:assetable_type => 'Host::Base').pluck(:assetable_id)
+    end
+
+    def hosts
+      Host.where(:id => host_ids)
+    end
+
+    def hosts=(hosts)
+      host_ids = hosts.map(&:id).map(&:to_s)
+    end
+
     def steps
       base_steps = ['Create policy', 'SCAP Content', 'Schedule']
       base_steps << 'Locations' if SETTINGS[:locations_enabled]

--- a/app/views/foreman_openscap/policy_mailer/_dashboard.erb
+++ b/app/views/foreman_openscap/policy_mailer/_dashboard.erb
@@ -1,0 +1,21 @@
+<% td_style = "font-size: 125%; width: 33%; padding: 5px; border: 1px solid #ccc;" %>
+<% p_style = "font-weight: bold; margin: 5px; padding: 0px;" %>
+<% b_style = "color: #6bb5df;" %>
+<table style="border: 1px solid #cccccc; padding: 5px; background-color: #ffffff; border-collapse: collapse; text-align: center; width: 100%">
+  <tbody>
+    <tr>
+      <td style="<%= td_style %>">
+        <b style="<%= b_style %>"><%= (changed_hosts.length.to_s).html_safe %></b>
+        <p style="<%= p_style %>"><%= _('Changed').html_safe %></p>
+      </td>
+      <td style="<%= td_style %>">
+        <b style="<%= b_style %>"><%= (compliant_hosts.length.to_s).html_safe %></b>
+        <p style="<%= p_style %>"><%= _('Compliant').html_safe %></p>
+      </td>
+      <td style="<%= td_style %>">
+        <b style="<%= b_style %>"><%= (incompliant_hosts.length.to_s).html_safe %></b>
+        <p style="<%= p_style %>"><%= _('Incompliant').html_safe %></p>
+      </td>
+    </tr>
+  </tbody>
+</table>

--- a/app/views/foreman_openscap/policy_mailer/_hosts.erb
+++ b/app/views/foreman_openscap/policy_mailer/_hosts.erb
@@ -1,0 +1,44 @@
+<% th_style = "text-align: left; border-collapse: collapse;  background: #f5f5f5; background: linear-gradient(#f5f5f5, #e8e8e8); padding: 4px; border: 1px solid #cccccc;" %>
+<% td_style = "text-align: left; border-collapse: collapse; background-color: #FFFFFF; padding: 4px; border: 1px solid #cccccc;" %>
+<tr>
+  <th style="<%= th_style %>">
+    <%= _('Hostname') %>
+  </th>
+  <th style="<%= th_style %>">
+    <%= _('Passed') %>
+  </th>
+  <th style="<%= th_style %>">
+    <%= _('Failed') %>
+  </th>
+  <th style="<%= th_style %>">
+    <%= _('Other') %>
+  </th>
+  <th style="<%= th_style %>">
+    <%= _('Changed?') %>
+  </th>
+</tr>
+<% hosts.each do |host| %>
+  <tr>
+    <% last_report = host.reports_for_policy(policy, 1).first %>
+
+    <%= render "host_mailer/link_to_host", :host => host %>
+    <% if last_report %>
+      <td style="<%= td_style %>">
+        <%= last_report.passed %>
+      </td>
+      <td style="<%= td_style %>">
+        <%= last_report.failed %>
+      </td>
+      <td style="<%= td_style %>">
+        <%= last_report.othered %>
+      </td>
+      <td style="<%= td_style %>">
+        <%= host.scap_status_changed?(policy) ? _('Yes') : _('No') %>
+      </td>
+    <% else %>
+      <td style="<%= td_style %> border-right: 0px;">
+        <%= _('No ARF reports for this policy') %>
+      </td>
+    <% end %>
+  </tr>
+<% end %>

--- a/app/views/foreman_openscap/policy_mailer/_list.erb
+++ b/app/views/foreman_openscap/policy_mailer/_list.erb
@@ -1,0 +1,10 @@
+<div>
+  <h2><%= title %></h2>
+  <% if list.size > 0 %>
+    <% list.each do |policy| %>
+      <%= render :partial => 'policy', :locals => { :policy => policy } %>
+    <% end%>
+  <% else %>
+    <b><%= _('None!') %></b>
+  <% end %>
+</div>

--- a/app/views/foreman_openscap/policy_mailer/_policy.erb
+++ b/app/views/foreman_openscap/policy_mailer/_policy.erb
@@ -1,0 +1,7 @@
+<h3><%= policy.name %></h3>
+<table style="border: 1px solid #cccccc; padding: 5px; background-color: #ffffff; border-collapse: collapse; text-align: justify; width: 100%;" bgcolor="#ffffff">
+      <tbody>
+        <%= render :partial => "hosts", :locals => { :hosts => policy.hosts, :policy => policy } %>
+      </tbody>
+    </table>
+    <p style="background-color: #e1e2e3; margin: 5px 0px; padding: 0px; line-height: 24px;"><%= n_('Total of one host', 'Total of %{hosts} hosts', policy.hosts.size) % {:hosts => policy.hosts.size} %></p>

--- a/app/views/foreman_openscap/policy_mailer/policy_summary.erb
+++ b/app/views/foreman_openscap/policy_mailer/policy_summary.erb
@@ -1,0 +1,19 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+
+<html>
+  <head>
+    <meta content="text/html; charset=UTF-8" http-equiv="Content-Type" />
+    <title> Summary report for OpenScap from Foreman </title>
+  </head>
+  <body style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; color: #3f3f3f; background-color: #f1f1f1; padding: 10px 24px">
+    <h2 style="font-weight: normal; text-transform: uppercase; font-size: 120%;"><%= _("<b>Foreman</b> OpenScap summary").html_safe %></h2>
+    <h2 style="margin: 5px 0px;"><%= _("Summary from %{time} ago to now") % {:time => distance_of_time_in_words(Time.now - @time)} %></h2>
+    <h3 style="margin: 0px;"><%= _("Summary report from Foreman server at %{foreman_url}") % {:foreman_url => Setting[:foreman_url]} %></h3>
+    <div style="background: #e1e2e3; padding: 20px 40px; margin: 5px 0px 10px;">
+      <%= render :partial => 'dashboard', :locals => {:changed_hosts => @changed_hosts, :compliant_hosts => @compliant_hosts, :incompliant_hosts =>  @incompliant_hosts} %>
+    </div>
+    <div style="background: #fff; padding: 10px 20px; border: 1px solid #e1e2e3">
+      <%= render :partial => 'list', :locals => {:title => _("Policies with hosts:"), :list => @policies} %>
+    </div>
+  </body>
+</html>

--- a/db/seeds.d/openscap_policy_notification.rb
+++ b/db/seeds.d/openscap_policy_notification.rb
@@ -1,0 +1,9 @@
+policy_notification = {
+  :name => :openscap_policy_summary,
+  :description => N_('A summary of reports for OpenScap policies'),
+  :mailer => 'ForemanOpenscap::PolicyMailer',
+  :method => 'policy_summary',
+  :subscription_type => 'report',
+}
+
+MailNotification.where(policy_notification).first_or_create

--- a/test/factories/arf_report_factory.rb
+++ b/test/factories/arf_report_factory.rb
@@ -4,5 +4,6 @@ FactoryGirl.define do
     f.policy
     f.sequence(:digest) { |n| "#{n}1212aa#{n}"}
     date '1973-01-13'
+    xccdf_rule_results []
   end
 end

--- a/test/factories/policy_factory.rb
+++ b/test/factories/policy_factory.rb
@@ -7,5 +7,6 @@ FactoryGirl.define do
     scap_content_profile
     day_of_month '1'
     cron_line '* * * * 30'
+    hosts []
   end
 end

--- a/test/factories/xccdf_rule_result_factory.rb
+++ b/test/factories/xccdf_rule_result_factory.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :xccdf_rule_result, :class => Scaptimony::XccdfRuleResult do
+    xccdf_result_id 1
+    xccdf_rule_id 1
+  end
+end

--- a/test/unit/arf_report_test.rb
+++ b/test/unit/arf_report_test.rb
@@ -1,0 +1,57 @@
+require 'test_plugin_helper'
+
+module ForemanOpenscap
+  class ArfReportTest < ActiveSupport::TestCase
+    setup do
+      disable_orchestration
+      User.current = users :admin
+      Scaptimony::Policy.any_instance.stubs(:ensure_needed_puppetclasses).returns(true)
+      @policy = FactoryGirl.create(:policy)
+      @asset = FactoryGirl.create(:asset)
+      @result_1 = FactoryGirl.build(:xccdf_rule_result, :xccdf_result_id => 1, :xccdf_rule_id => 1)
+      @result_2 = FactoryGirl.build(:xccdf_rule_result, :xccdf_result_id => 2, :xccdf_rule_id => 2)
+      @result_3 = FactoryGirl.build(:xccdf_rule_result, :xccdf_result_id => 1, :xccdf_rule_id => 1)
+    end
+
+    test 'equal? should return true when there is no change in report results' do
+      result_4 = FactoryGirl.build(:xccdf_rule_result, :xccdf_result_id => 2, :xccdf_rule_id => 2)
+      report_1 = FactoryGirl.create(:arf_report, :policy => @policy, :asset => @asset, :xccdf_rule_results => [@result_1, @result_2])
+      report_2 = FactoryGirl.create(:arf_report, :policy => @policy, :asset => @asset, :xccdf_rule_results => [@result_3, result_4])
+
+      assert(report_1.equal? report_2)
+    end
+
+    test 'equal? should return false when there is change in report results' do
+      result_4 = FactoryGirl.build(:xccdf_rule_result, :xccdf_result_id => 2, :xccdf_rule_id => 6)
+      report_1 = FactoryGirl.create(:arf_report, :policy => @policy, :asset => @asset, :xccdf_rule_results => [@result_1, @result_2])
+      report_2 = FactoryGirl.create(:arf_report, :policy => @policy, :asset => @asset, :xccdf_rule_results => [@result_3, result_4])
+
+      refute(report_1.equal? report_2)
+    end
+
+    test 'equal? should return false when reports have different sets of rules' do
+      report_1 = FactoryGirl.create(:arf_report, :policy => @policy, :asset => @asset, :xccdf_rule_results => [@result_1, @result_2])
+      report_2 = FactoryGirl.create(:arf_report, :policy => @policy, :asset => @asset, :xccdf_rule_results => [@result_3])
+
+      refute(report_1.equal? report_2)
+    end
+
+    test 'equal? should return false when reports have different assets' do
+      asset = FactoryGirl.create(:asset)
+      result_4 = FactoryGirl.build(:xccdf_rule_result, :xccdf_result_id => 2, :xccdf_rule_id => 2)
+      report_1 = FactoryGirl.create(:arf_report, :policy => @policy, :asset => @asset, :xccdf_rule_results => [@result_1, @result_2])
+      report_2 = FactoryGirl.create(:arf_report, :policy => @policy, :asset => asset, :xccdf_rule_results => [@result_3, result_4])
+
+      refute(report_1.equal? report_2)
+    end
+
+    test 'equal? should return false when reports have different policies' do
+      policy = FactoryGirl.create(:policy)
+      result_4 = FactoryGirl.build(:xccdf_rule_result, :xccdf_result_id => 2, :xccdf_rule_id => 2)
+      report_1 = FactoryGirl.create(:arf_report, :policy => @policy, :asset => @asset, :xccdf_rule_results => [@result_1, @result_2])
+      report_2 = FactoryGirl.create(:arf_report, :policy => policy, :asset => @asset, :xccdf_rule_results => [@result_3, result_4])
+
+      refute(report_1.equal? report_2)
+    end
+  end
+end

--- a/test/unit/openscap_host_test.rb
+++ b/test/unit/openscap_host_test.rb
@@ -5,23 +5,45 @@ class OpenscapHostTest < ActiveSupport::TestCase
     disable_orchestration
     User.current = users :admin
     Scaptimony::Policy.any_instance.stubs(:ensure_needed_puppetclasses).returns(true)
+    @policy = FactoryGirl.create(:policy)
   end
 
   test 'Host has policy' do
     host = FactoryGirl.create(:host)
     assert_empty(host.policies)
-    policy = FactoryGirl.create(:policy)
 
-    assert(policy.assign_hosts([host]), 'Host policies should be assigned')
-    assert_includes(host.policies, policy)
+    assert(@policy.assign_hosts([host]), 'Host policies should be assigned')
+    assert_includes(host.policies, @policy)
   end
 
   test 'Host has policies via its hostgroup' do
     host = FactoryGirl.create(:host, :with_hostgroup)
     hostgroup = host.hostgroup
-    policy = FactoryGirl.create(:policy)
-    assert(policy.hostgroup_ids = ["#{hostgroup.id}"])
+    assert(@policy.hostgroup_ids = ["#{hostgroup.id}"])
     refute_empty(host.combined_policies)
-    assert_includes(host.combined_policies, policy)
+    assert_includes(host.combined_policies, @policy)
+  end
+
+  context 'testing scap_status_changed?' do
+    setup do
+      @host = FactoryGirl.create(:host)
+      @report_1 = FactoryGirl.create(:arf_report, :policy => @policy, :host => @host)
+      @report_2 = FactoryGirl.create(:arf_report, :policy => @policy, :host => @host)
+    end
+
+    test 'scap_status_changed should detect status change' do
+      Scaptimony::ArfReport.any_instance.stubs(:equal?).returns(false)
+      refute(@host.scap_status_changed?(@policy))
+    end
+
+    test 'scap_status_changed should not detect status change when there is none' do
+      Scaptimony::ArfReport.any_instance.stubs(:equal?).returns(true)
+      refute(@host.scap_status_changed?(@policy))
+    end
+
+    test 'scap_status_changed should not detect status change when there are reports < 2' do
+      @report_2.destroy
+      refute(@host.scap_status_changed?(@policy))
+    end
   end
 end

--- a/test/unit/policy_mailer_test.rb
+++ b/test/unit/policy_mailer_test.rb
@@ -1,0 +1,38 @@
+require 'test_plugin_helper'
+
+class PolicyMailerTest < ActiveSupport::TestCase
+  setup do
+    @user = User.current = users :admin
+
+    FactoryGirl.create(:mail_notification,
+                       :name => :openscap_policy_summary,
+                       :description => N_('A summary of reports for OpenScap policies'),
+                       :mailer => 'ForemanOpenscap::PolicyMailer',
+                       :method => 'policy_summary',
+                       :subscription_type => 'report',
+    )
+
+    @user.mail_notifications << MailNotification[:openscap_policy_summary]
+
+    ActionMailer::Base.deliveries = []
+    @user.user_mail_notifications.first.deliver
+    @email = ActionMailer::Base.deliveries.first
+  end
+
+  test 'policy mailer should deliver summary' do
+    assert @email.to.include?("admin@someware.com")
+  end
+
+  test 'policy mailer should contain body' do
+    refute @email.body.nil?
+  end
+
+  test 'policy mailer should have a correct subject' do
+    refute @email.subject.empty?
+    assert @email.subject.include? Setting[:email_subject_prefix]
+  end
+
+  test 'policy mailer sends Foreman URL in body' do
+    assert @email.body.include? Setting[:foreman_url]
+  end
+end


### PR DESCRIPTION
User can subscribe to receive a regular summary of OpenScap policies. Summary contains overview of policies with host status and if there has been any recent change in host compliance. 