### PR TITLE
Fixes #9758 - Multiple Arf reports can be deleted simultaneously

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -252,3 +252,6 @@ Style/StringLiterals:
 # Configuration parameters: EnforcedStyleForMultiline, SupportedStyles.
 Style/TrailingComma:
   Enabled: false
+
+Performance/Count:
+  Enabled: false

--- a/app/assets/javascripts/foreman_openscap/arf_reports.js
+++ b/app/assets/javascripts/foreman_openscap/arf_reports.js
@@ -1,0 +1,16 @@
+function buildArfModal(element, url) {
+  var url = url + "?" + $.param({arf_report_ids: $.foremanSelectedHosts});
+  var title = $(element).attr('data-dialog-title');
+  $('#confirmation-modal .modal-header h4').text(title);
+  $("#confirmation-modal .modal-body").load(url + " #content",
+      function(response, status, xhr) {
+        $('#submit_multiple').val('');
+        var b = $("#confirmation-modal .btn-primary");
+        if ($(response).find('#content form select').length > 0)
+          b.addClass("disabled").attr("disabled", true);
+        else
+          b.removeClass("disabled").attr("disabled", false);
+        $('#confirmation-modal').modal();
+        });
+  return false;
+}

--- a/app/assets/stylesheets/foreman_openscap/policy.css
+++ b/app/assets/stylesheets/foreman_openscap/policy.css
@@ -5,3 +5,4 @@
 .hide-pane {
   display: none;
 }
+

--- a/app/helpers/arf_reports_helper.rb
+++ b/app/helpers/arf_reports_helper.rb
@@ -48,4 +48,18 @@ module ArfReportsHelper
           end
     "class='label label-#{tag}'".html_safe
   end
+
+  def multiple_actions_arf_report
+    actions = [
+      [_('Delete reports'), delete_multiple_arf_reports_path]
+    ]
+  end
+
+  def multiple_actions_arf_report_select
+    select_action_button(_("Select Action"), {:id => 'submit_multiple'},
+      multiple_actions_arf_report.map do |action|
+        link_to_function(action[0], "buildArfModal(this, '#{action[1]}')",
+         :'data-dialog-title' => _("%s - The following compliance reports are about to be changed") % action[0])
+      end.flatten)
+  end
 end

--- a/app/views/arf_reports/_list.html.erb
+++ b/app/views/arf_reports/_list.html.erb
@@ -1,5 +1,8 @@
+<%= javascript "jquery.cookie", "host_checkbox", "foreman_openscap/arf_reports" %>
+
 <table class="table table-bordered table-striped ellipsis">
   <tr>
+  <th class="ca" width="40px"><%= check_box_tag "check_all", "", false, { :onclick => "toggleCheck()", :'check-title' => _("Select all items in this page"), :'uncheck-title'=> _("items selected. Uncheck to Clear") } %></th>
     <th><%= sort :host %></th>
     <th><%= sort :reported_at, :as => _("Reported At") %></th>
     <th><%= sort :passed, :as => _("Passed") %></th>
@@ -9,6 +12,9 @@
   </tr>
   <% for arf_report in @arf_reports %>
     <tr>
+    <td class="ca">
+          <%= check_box_tag "host_ids[]", nil, false, :id => "host_ids_#{arf_report.id}", :disabled => !authorized?, :class => 'host_select_boxes', :onclick => 'hostChecked(this)' %>
+        </td>
       <td><%= name_column(arf_report.host) %></td>
       <td><%= _("%s ago") % time_ago_in_words(arf_report.reported_at) %></td>
       <td><%= report_arf_column(arf_report.passed, "label-info") %></th>
@@ -24,4 +30,20 @@
     </tr>
   <% end %>
 </table>
+<div id="confirmation-modal" class="modal fade">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+        <h4 class="modal-title"><%= _('Please Confirm') %></h4>
+      </div>
+      <div class="modal-body">
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-default" data-dismiss="modal"><%= _('Cancel') %></button>
+        <button type="button" class="btn btn-primary" onclick="submit_modal_form()"><%= _('Submit') %></button>
+      </div>
+    </div>
+  </div>
+</div>
 <%= will_paginate_with_info @arf_reports %>

--- a/app/views/arf_reports/delete_multiple.html.erb
+++ b/app/views/arf_reports/delete_multiple.html.erb
@@ -1,0 +1,29 @@
+<div class="row">
+  <div class="col-md-8">
+    <table class="table table-bordered table-striped">
+      <thead>
+        <tr>
+          <th>
+            <%= _("Host") %>
+          </th>
+          <th>
+            <%= _("Reported At") %>
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <% @arf_reports.each do |report| %>
+          <tr>
+            <td><%= report.host %></td>
+            <td><%=h report.created_at %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+</div>
+
+<%= form_tag submit_delete_multiple_arf_reports_path({:arf_report_ids => params[:arf_report_ids]}) do %>
+  <span class="label label-danger"><%= _('Delete') %></span>
+  <%= _('these Complinace reports') %>
+<% end %>

--- a/app/views/arf_reports/index.html.erb
+++ b/app/views/arf_reports/index.html.erb
@@ -1,4 +1,4 @@
 <% title _("Compliance Reports") %>
-
+<% title_actions multiple_actions_arf_report_select %>
 <%= render :partial => 'list' %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,8 @@ Rails.application.routes.draw do
       end
       collection do
         get 'auto_complete_search'
+        get 'delete_multiple'
+        post 'submit_delete_multiple'
       end
     end
 

--- a/lib/foreman_openscap/engine.rb
+++ b/lib/foreman_openscap/engine.rb
@@ -52,7 +52,7 @@ module ForemanOpenscap
                                                           :parse_bzip, :auto_complete_search],
                                          'api/v2/compliance/arf_reports' => [:index, :show],
                                          :compliance_hosts => [:show]}
-          permission :destroy_arf_reports, {:arf_reports => [:destroy],
+          permission :destroy_arf_reports, {:arf_reports => [:destroy, :delete_multiple, :submit_delete_multiple],
                                             'api/v2/compliance/arf_reports' => [:destroy]}
           permission :create_arf_reports, {'api/v2/compliance/arf_reports' => [:create]}
 

--- a/test/factories/arf_report_factory.rb
+++ b/test/factories/arf_report_factory.rb
@@ -4,6 +4,7 @@ FactoryGirl.define do
     policy nil
     policy_arf_report nil
     sequence(:reported_at) { |n| Time.new(1490 + n, 01, 13, 15, 24, 00) }
+    sequence(:created_at) { |n| Time.new(1490 + n, 01, 13, 15, 24, 00) }
     logs []
     status 0
     metrics {}

--- a/test/functional/arf_reports_controller_test.rb
+++ b/test/functional/arf_reports_controller_test.rb
@@ -1,0 +1,22 @@
+require 'test_plugin_helper'
+
+class ArfReportsControllerTest < ActionController::TestCase
+
+  test "should delete selected reports" do
+    host = FactoryGirl.create(:compliance_host)
+    openscap_proxy = ::ProxyAPI::Openscap.new(:url => "http://test.org:8080")
+    ForemanOpenscap::Helper.stubs(:find_name_or_uuid_by_host)
+    ::ProxyAPI::Openscap.any_instance.stubs(:destroy_report).returns(true)
+    ForemanOpenscap::ArfReport.any_instance.stubs(:proxy).returns(openscap_proxy)
+    arf_reports = []
+    3.times do
+      arf_reports << FactoryGirl.create(:arf_report, :host_id => host.id)
+    end
+    last_arf = arf_reports[-1]
+    assert_difference("ForemanOpenscap::ArfReport.count", -2) do
+      post :submit_delete_multiple, { :arf_report_ids => arf_reports[0..-2].map(&:id) }, set_session_user
+    end
+    assert_redirected_to arf_reports_path
+    assert_equal last_arf, ForemanOpenscap::ArfReport.first
+  end
+end


### PR DESCRIPTION
We can expire multiple Arf reports at the same time based on their created_at time. Reports older than supplied number of days will be expired. I am not sure if this is exactly what we want so I tried to keep it as simple as possible.