### PR TITLE
Fixes #9766 - Openscap Proxy can be selected by a user

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -33,7 +33,7 @@ Lint/UselessAssignment:
 
 # Offense count: 19
 Metrics/AbcSize:
-  Max: 40
+  Max: 42
 
 # Offense count: 6
 # Configuration parameters: CountComments.
@@ -47,7 +47,7 @@ Metrics/CyclomaticComplexity:
 # Offense count: 23
 # Configuration parameters: CountComments.
 Metrics/MethodLength:
-  Max: 24
+  Max: 26
 
 # Offense count: 3
 Metrics/PerceivedComplexity:

--- a/app/assets/javascripts/foreman_openscap/openscap_proxy.js
+++ b/app/assets/javascripts/foreman_openscap/openscap_proxy.js
@@ -1,0 +1,52 @@
+function updateOpenscapProxy(element){
+  var id = $("form").data('id')
+  var url = $(element).attr('data-url');
+  var data = $("form").serialize().replace('method=put', 'method=post');
+  if (url.match('hostgroups')) {
+    data = data + '&hostgroup_id=' + id
+  } else {
+    data = data + '&host_id=' + id
+  }
+
+  toggleErrorText("");
+  $(element).indicator_show();
+  $.ajax({
+    type: 'post',
+    url:  url,
+    data: data,
+    error: function(response) {
+      var text = $(response.responseText).find('.form-group.has-error').find('.help-block.help-inline').text();
+      addOpenscapProxyError(text);
+      $(element).indicator_hide();
+    },
+    success: function(response) {
+      removeOpenscapProxyError();
+      $('#puppetclasses_parameters').replaceWith($(response).find("#puppetclasses_parameters"));
+      $(element).indicator_hide();
+    }
+  })
+}
+
+function findOpenscapProxyFormGroup(){
+  return $('form').find("label[for='openscap_proxy_id']").parents(".form-group").first();
+}
+
+function addOpenscapProxyError(text){
+  var formGroup = findOpenscapProxyFormGroup();
+  $(formGroup).addClass("has-error");
+  toggleErrorText(text);
+}
+
+function removeOpenscapProxyError(){
+  var formGroup = findOpenscapProxyFormGroup();
+  $(formGroup).removeClass("has-error");
+  toggleErrorText("");
+}
+
+function toggleErrorText(text){
+  if(text){
+    $(findOpenscapProxyFormGroup()).find(".help-block.help-inline").append('<span id="openscap_error">' + text + '</span>');
+  } else {
+    $(findOpenscapProxyFormGroup()).find("#openscap_error").remove();
+  }
+}

--- a/app/controllers/concerns/foreman_openscap/hostgroups_controller_extensions.rb
+++ b/app/controllers/concerns/foreman_openscap/hostgroups_controller_extensions.rb
@@ -1,0 +1,20 @@
+module ForemanOpenscap
+  module HostgroupsControllerExtensions
+    extend ActiveSupport::Concern
+
+    included do
+      alias_method_chain :load_vars_for_ajax, :openscap
+      alias_method_chain :inherit_parent_attributes, :openscap
+    end
+
+    def load_vars_for_ajax_with_openscap
+      load_vars_for_ajax_without_openscap
+      @openscap_proxy = @hostgroup.openscap_proxy
+    end
+
+    def inherit_parent_attributes_with_openscap
+      inherit_parent_attributes_without_openscap
+      @hostgroup.openscap_proxy ||= @parent.openscap_proxy
+    end
+  end
+end

--- a/app/controllers/concerns/foreman_openscap/hosts_common_controller_extensions.rb
+++ b/app/controllers/concerns/foreman_openscap/hosts_common_controller_extensions.rb
@@ -1,0 +1,45 @@
+module ForemanOpenscap
+  module HostsCommonControllerExtensions
+    extend ActiveSupport::Concern
+
+    def openscap_proxy_changed
+      model = if params[param_id_key].blank?
+                controller_name.classify.constantize.new(params[param_model_key])
+              else
+                resource_base.find(params[param_id_key])
+              end
+      proxy_id = params[param_model_key][:openscap_proxy_id]
+      instance_variable_set("@#{param_model_key}", model)
+      if proxy_id.blank?
+        render :partial => "form"
+      else
+        begin
+          instance_variable_get("@#{param_model_key}").update_scap_client_params(proxy_id)
+          render :partial => "form"
+        rescue => e
+          instance_variable_get("@#{param_model_key}").errors.add(:openscap_proxy_id, e.message)
+          render :partial => "form", :status => 422
+        end
+      end
+    end
+
+    def action_permission
+      case params[:action]
+      when 'openscap_proxy_changed'
+        :edit
+      else
+        super
+      end
+    end
+
+    private
+
+    def param_id_key
+      "#{param_model_key}_id"
+    end
+
+    def param_model_key
+      controller_name.singularize
+    end
+  end
+end

--- a/app/controllers/concerns/foreman_openscap/hosts_controller_extensions.rb
+++ b/app/controllers/concerns/foreman_openscap/hosts_controller_extensions.rb
@@ -1,0 +1,17 @@
+module ForemanOpenscap
+  module HostsControllerExtensions
+    extend ActiveSupport::Concern
+
+    included do
+      alias_method_chain :process_hostgroup, :openscap
+      self::AJAX_REQUESTS << 'openscap_proxy_changed'
+    end
+
+    def process_hostgroup_with_openscap
+      @hostgroup = Hostgroup.find(params[:host][:hostgroup_id]) if params[:host][:hostgroup_id].to_i > 0
+      return head(:not_found) unless @hostgroup
+      @openscap_proxy = @hostgroup.openscap_proxy
+      process_hostgroup_without_openscap
+    end
+  end
+end

--- a/app/models/concerns/foreman_openscap/hostgroup_extensions.rb
+++ b/app/models/concerns/foreman_openscap/hostgroup_extensions.rb
@@ -7,5 +7,17 @@ module ForemanOpenscap
       has_many :asset_policies, :through => :asset, :class_name => "::ForemanOpenscap::AssetPolicy"
       has_many :policies, :through => :asset_policies, :class_name => "::ForemanOpenscap::Policy"
     end
+
+    unless defined?(Katello::System)
+      private
+
+      def inherited_ancestry_attribute(attribute)
+        if ancestry.present?
+          self[attribute] || self.class.sort_by_ancestry(ancestors.where("#{attribute} is not NULL")).last.try(attribute)
+        else
+          self.send(attribute)
+        end
+      end
+    end
   end
 end

--- a/app/models/concerns/foreman_openscap/openscap_proxy_core_extensions.rb
+++ b/app/models/concerns/foreman_openscap/openscap_proxy_core_extensions.rb
@@ -1,0 +1,55 @@
+module ForemanOpenscap
+  module OpenscapProxyCoreExtensions
+    extend ActiveSupport::Concern
+
+    included do
+      validate :openscap_proxy_has_feature
+    end
+
+    def update_scap_client_params(proxy_id)
+      new_proxy = SmartProxy.find proxy_id
+      model_match = self.class.name.underscore.match(/\Ahostgroup\z/) ? "hostgroup" : "fqdn"
+      puppetclass = Puppetclass.find_by_name("foreman_scap_client")
+      fail _("Puppetclass 'foreman_scap_client' not found, make sure it is imported form Puppetmaster") if puppetclass.nil?
+      scap_params = puppetclass.class_params
+      server_lookup_key = scap_params.find { |param| param.key == "server" }
+      port_lookup_key = scap_params.find { |param| param.key == "port" }
+      pairs = scap_client_lookup_values_for([server_lookup_key, port_lookup_key], model_match)
+      mapping = { "server" => new_proxy.hostname, "port" => new_proxy.port }
+      update_scap_client_lookup_values(pairs, model_match, mapping)
+    end
+
+    def inherited_openscap_proxy_id
+      inherited_ancestry_attribute(:openscap_proxy_id)
+    end
+
+    private
+
+    def scap_client_lookup_values_for(lookup_keys, model_match)
+      lookup_keys.inject({}) do |result, key|
+        result[key] = key.lookup_values.find { |value| value.match == "#{lookup_matcher(model_match)}" }
+        result
+      end
+    end
+
+    def update_scap_client_lookup_values(pairs, model_match, mapping)
+      pairs.each do |k, v|
+        if v.nil?
+          LookupValue.create(:match => lookup_matcher(model_match), :value => mapping[k.key], :lookup_key_id => k.id)
+        else
+          v.value = mapping[k.key]
+          v.save
+        end
+      end
+    end
+
+    def lookup_matcher(model_match)
+      model_match == "fqdn" ? "#{model_match}=#{name}" : "#{model_match}=#{title}"
+    end
+
+    def openscap_proxy_has_feature
+      return true unless openscap_proxy_id
+      openscap_proxy.has_feature? "Openscap"
+    end
+  end
+end

--- a/app/models/concerns/foreman_openscap/openscap_proxy_extensions.rb
+++ b/app/models/concerns/foreman_openscap/openscap_proxy_extensions.rb
@@ -1,0 +1,17 @@
+module ForemanOpenscap
+  module OpenscapProxyExtensions
+    extend ActiveSupport::Concern
+
+    included do
+      belongs_to :openscap_proxy, :class_name => "SmartProxy"
+      attr_accessible :openscap_proxy_id
+    end
+
+    def openscap_proxy_api
+      return @openscap_api if @openscap_api
+      proxy_url = openscap_proxy.url
+      fail(_("No openscap proxy found for %s") % name) unless proxy_url
+      @openscap_api = ::ProxyAPI::Openscap.new(:url => proxy_url)
+    end
+  end
+end

--- a/app/models/concerns/foreman_openscap/smart_proxy_extensions.rb
+++ b/app/models/concerns/foreman_openscap/smart_proxy_extensions.rb
@@ -1,0 +1,23 @@
+module ForemanOpenscap
+  module SmartProxyExtensions
+    extend ActiveSupport::Concern
+
+    included do
+      has_many :openscap_hostgroups, :foreign_key => 'openscap_proxy_id', :class_name => "::Hostgroup"
+      has_many :openscap_hosts, :foreign_key => 'openscap_proxy_id', :class_name => "::Host"
+      has_many :arf_reports, :foreign_key => 'openscap_proxy_id', :class_name => "ForemanOpenscap::ArfReport"
+      PORT_MATCH = /:(\d+)\z/
+      after_destroy :delete_associated_arf_reports
+    end
+
+    def port
+      url.match(PORT_MATCH)[1]
+    end
+
+    private
+
+    def delete_associated_arf_reports
+      ForemanOpenscap::ArfReport.where(:openscap_proxy_id => id).delete_all
+    end
+  end
+end

--- a/app/overrides/hostgroups/form/select_openscap_proxy.rb
+++ b/app/overrides/hostgroups/form/select_openscap_proxy.rb
@@ -1,0 +1,4 @@
+Deface::Override.new(:virtual_path => "hostgroups/_form",
+                     :name => "choose_openscap_proxy",
+                     :insert_bottom => "#primary",
+                     :partial => "compliance_hosts/openscap_proxy")

--- a/app/overrides/hosts/form/select_openscap_proxy.rb
+++ b/app/overrides/hosts/form/select_openscap_proxy.rb
@@ -1,0 +1,4 @@
+Deface::Override.new(:virtual_path => "hosts/_form",
+                     :name => "openscap_proxy",
+                     :insert_bottom => "#primary",
+                     :partial => "compliance_hosts/openscap_proxy")

--- a/app/views/compliance_hosts/_openscap_proxy.html.erb
+++ b/app/views/compliance_hosts/_openscap_proxy.html.erb
@@ -1,0 +1,8 @@
+<%= javascript 'foreman_openscap/openscap_proxy' %>
+<% data_url = @host ? openscap_proxy_changed_hosts_path : openscap_proxy_changed_hostgroups_path%>
+<%= select_f f, :openscap_proxy_id, SmartProxy.with_features("Openscap"), :id, :name,
+    { :include_blank => blank_or_inherit_f(f, :openscap_proxy) },
+    { :label => _('Openscap Proxy'),
+      :onchange => 'updateOpenscapProxy(this)',
+      :'data-url' => data_url,
+      :help_inline => :indicator } %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -56,3 +56,17 @@ Rails.application.routes.draw do
     end
   end
 end
+
+Foreman::Application.routes.draw do
+  resources :hosts do
+    collection do
+      post 'openscap_proxy_changed'
+    end
+  end
+
+  resources :hostgroups do
+    collection do
+      post 'openscap_proxy_changed'
+    end
+  end
+end

--- a/db/migrate/20151120090851_add_openscap_proxy_to_host_and_hostgroup.rb
+++ b/db/migrate/20151120090851_add_openscap_proxy_to_host_and_hostgroup.rb
@@ -1,0 +1,25 @@
+class AddOpenscapProxyToHostAndHostgroup < ActiveRecord::Migration
+  def up
+    add_column :hostgroups, :openscap_proxy_id, :integer
+    add_column :hosts, :openscap_proxy_id, :integer
+    add_column :reports, :openscap_proxy_id, :integer
+
+    #to ensure backward compatiblity
+    #this relies on the fact that only one scap proxy was registered
+    #because there has not been support for multiple scap proxies
+    reports = ForemanOpenscap::ArfReport.where(:openscap_proxy_id => nil)
+    scap_proxy = SmartProxy.with_features("Openscap").first
+    unless scap_proxy.nil?
+      reports.each do |report|
+        report.openscap_proxy = scap_proxy
+        report.save!
+      end
+    end
+  end
+
+  def down
+    remove_column :hostgroups, :openscap_proxy_id, :integer
+    remove_column :hosts, :openscap_proxy_id, :integer
+    remove_column :reports, :openscap_proxy_id
+  end
+end

--- a/lib/foreman_openscap/engine.rb
+++ b/lib/foreman_openscap/engine.rb
@@ -86,6 +86,8 @@ module ForemanOpenscap
           permission :destroy_scap_contents, {:scap_contents => [:destroy],
                                                          'api/v2/compliance/scap_contents' => [:destroy]},
                      :resource_type => 'ForemanOpenscap::ScapContent'
+          permission :edit_hosts, { :hosts => [:openscap_proxy_changed] }, :resource_type => "Host"
+          permission :edit_hostgroups, { :hostgroups => [:openscap_proxy_changed] }, :resource_type => "Hostgroup"
         end
 
         role "Compliance viewer", [:view_arf_reports, :view_policies, :view_scap_contents]
@@ -125,10 +127,19 @@ module ForemanOpenscap
 
     #Include concerns in this config.to_prepare block
     config.to_prepare do
+      Host::Managed.send(:include, ForemanOpenscap::OpenscapProxyExtensions)
+      Host::Managed.send(:include, ForemanOpenscap::OpenscapProxyCoreExtensions)
       Host::Managed.send(:include, ForemanOpenscap::HostExtensions)
       HostsHelper.send(:include, ForemanOpenscap::HostsHelperExtensions)
       Hostgroup.send(:include, ForemanOpenscap::HostgroupExtensions)
+      Hostgroup.send(:include, ForemanOpenscap::OpenscapProxyExtensions)
+      Hostgroup.send(:include, ForemanOpenscap::OpenscapProxyCoreExtensions)
       Report.send(:include, ForemanOpenscap::ComplianceStatusScopedSearch)
+      SmartProxy.send(:include, ForemanOpenscap::SmartProxyExtensions)
+      HostsController.send(:include, ForemanOpenscap::HostsControllerExtensions)
+      HostsController.send(:include, ForemanOpenscap::HostsCommonControllerExtensions)
+      HostgroupsController.send(:include, ForemanOpenscap::HostgroupsControllerExtensions)
+      HostgroupsController.send(:include, ForemanOpenscap::HostsCommonControllerExtensions)
     end
 
     rake_tasks do

--- a/test/unit/arf_report_test.rb
+++ b/test/unit/arf_report_test.rb
@@ -147,10 +147,10 @@ module ForemanOpenscap
     end
 
     test 'should destroy report' do
-      proxy = ::ProxyAPI::Openscap.new(:url => 'https://test-proxy.com:9090')
-      proxy.stubs(:destroy_report).returns(true)
+      openscap_proxy_api = ::ProxyAPI::Openscap.new(:url => 'https://test-proxy.com:9090')
+      openscap_proxy_api.stubs(:destroy_report).returns(true)
       ForemanOpenscap::Helper.stubs(:find_name_or_uuid_by_host).returns("abcde")
-      ForemanOpenscap::ArfReport.any_instance.stubs(:proxy).returns(proxy)
+      ForemanOpenscap::ArfReport.any_instance.stubs(:openscap_proxy_api).returns(openscap_proxy_api)
       report = FactoryGirl.create(:arf_report, :policy => @policy, :host_id => @host.id, :logs => [@log_1, @log_2])
       report.destroy
       refute ForemanOpenscap::ArfReport.all.include? report

--- a/test/unit/openscap_host_test.rb
+++ b/test/unit/openscap_host_test.rb
@@ -51,10 +51,10 @@ class OpenscapHostTest < ActiveSupport::TestCase
     end
 
     test 'scap_status_changed should not detect status change when there are reports < 2' do
-      proxy = ::ProxyAPI::Openscap.new(:url => 'https://test-proxy.com:9090')
-      proxy.stubs(:destroy_report).returns(true)
+      openscap_proxy_api = ::ProxyAPI::Openscap.new(:url => 'https://test-proxy.com:9090')
+      openscap_proxy_api.stubs(:destroy_report).returns(true)
       ForemanOpenscap::Helper.stubs(:find_name_or_uuid_by_host).returns("abcde")
-      ForemanOpenscap::ArfReport.any_instance.stubs(:proxy).returns(proxy)
+      ForemanOpenscap::ArfReport.any_instance.stubs(:openscap_proxy_api).returns(openscap_proxy_api)
       @report_2.destroy
       refute @host.scap_status_changed?(@policy)
     end


### PR DESCRIPTION
* Dropdowns in host/hostgroup form that allow user to select openscap proxy for a host/hostgroup
* Each ArfReport is attached to the proxy and we are able to download report even if the host changes openscap proxy - as long as the proxy is registered in Foreman
* When the openscap proxy is destroyed, all associated reports are deleted from Foreman, but I do not bother doing cleanup (deleting reports from proxy) because we removed the proxy from Foreman and we do not care about it anymore.
* When host/hostgroup is saved with new openscap proxy, it configures the scap_client with the name and port from the new proxy.