### PR TITLE
Skip scap_content validation in rake db:seed if no scap proxy

### DIFF
--- a/lib/foreman_openscap/bulk_upload.rb
+++ b/lib/foreman_openscap/bulk_upload.rb
@@ -15,10 +15,12 @@ module ForemanOpenscap
       end
 
       files_array = `rpm -ql scap-security-guide | grep ds.xml`.split
-      upload_from_files(files_array) unless files_array.empty?
+      # If no proxy with Openscap feature, we're gonna skip scap_security_guide files validation
+      skip_validation = (!SmartProxy.with_features('Openscap').any? && ensure_in_db_seed)
+      upload_from_files(files_array, skip_validation) unless files_array.empty?
     end
 
-    def upload_from_files(files_array)
+    def upload_from_files(files_array, skip_validation = false)
       files_array.each do |datastream|
         file = File.open(datastream, 'rb').read
         digest = Digest::SHA2.hexdigest(datastream)
@@ -30,11 +32,19 @@ module ForemanOpenscap
         scap_content.original_filename = filename
         scap_content.location_ids = Location.all.map(&:id) if SETTINGS[:locations_enabled]
         scap_content.organization_ids = Organization.all.map(&:id) if SETTINGS[:organizations_enabled]
-        next puts "## SCAP content is invalid: #{scap_content.errors.full_messages.uniq.join(',')} ##" unless scap_content.valid?
-        if scap_content.save
-          puts "Saved #{datastream} as #{scap_content.title}"
+        if skip_validation
+          if (scap_content.save(:validate => false))
+            puts "Saved #{datastream} as #{scap_content.title}"
+          else
+            puts "Failed saving #{datastream}"
+          end
         else
-          puts "Failed saving #{datastream}"
+          next puts "## SCAP content is invalid: #{scap_content.errors.full_messages.uniq.join(',')} ##" unless scap_content.valid?
+          if scap_content.save
+            puts "Saved #{datastream} as #{scap_content.title}"
+          else
+            puts "Failed saving #{datastream}"
+          end
         end
       end
     end
@@ -59,6 +69,10 @@ module ForemanOpenscap
     def content_name(datastream)
       os_name = extract_name_from_file(datastream)
       @from_scap_security_guide ? "Red Hat #{os_name} default content" : "#{os_name} content"
+    end
+
+    def ensure_in_db_seed
+      defined?(Rake) && Rake.application.top_level_tasks.include?('db:seed')
     end
   end
 end


### PR DESCRIPTION
Since 0.5.x we have moved scap validation to the proxy.
In rake db:seed, it is possible that smart_proxy_openscap feature is missing and
seed will fail.
As we are importing scap_security_guide content we can skip this validation if no proxy with
Openscap feature is present.