### PR TITLE
Remove db:seed job and introduce it as a rake task

### DIFF
--- a/app/lib/proxy_api/available_proxy.rb
+++ b/app/lib/proxy_api/available_proxy.rb
@@ -13,14 +13,27 @@ module ::ProxyAPI
 
     def initialize(args)
       @features = ::ProxyAPI::Features.new(args).features
+      @versions = ::ProxyAPI::Version.new(args).proxy_versions['modules']
     end
 
     def available?
       begin
-        return true if @features.include?('openscap')
+        return true if (@features.include?('openscap') && minimum_version)
       rescue *HTTP_ERRORS
         return false
       end
+      false
+    end
+
+    private
+
+    def openscap_proxy_version
+      @versions['openscap'] if @versions['openscap']
+    end
+
+    def minimum_version
+      return false unless openscap_proxy_version
+      openscap_proxy_version.to_f >= 0.5
     end
   end
 end

--- a/db/seeds.d/openscap_scap_default.rb
+++ b/db/seeds.d/openscap_scap_default.rb
@@ -1,2 +1,0 @@
-require 'foreman_openscap/bulk_upload'
-ForemanOpenscap::BulkUpload.new(true).generate_scap_default_content

--- a/lib/tasks/foreman_openscap_tasks.rake
+++ b/lib/tasks/foreman_openscap_tasks.rake
@@ -15,6 +15,10 @@ namespace :foreman_openscap do
       end
       ForemanOpenscap::BulkUpload.new.upload_from_files(files_array)
     end
+
+    task :default => [:environment] do
+      ForemanOpenscap::BulkUpload.new(true).generate_scap_default_content
+    end
   end
 
   task :rubocop do

--- a/test/test_plugin_helper.rb
+++ b/test/test_plugin_helper.rb
@@ -14,6 +14,8 @@ Spork.each_run do
     def add_smart_proxy
       FactoryGirl.create(:smart_proxy, :url => 'http://localhost:8443', :features => [FactoryGirl.create(:feature, :name => 'Openscap')])
       ::ProxyAPI::Features.any_instance.stubs(:features).returns(%w(puppet openscap))
+      versions = { "version" => "1.11.0", "modules" => { "openscap" => "0.5.3" } }
+      ::ProxyAPI::Version.any_instance.stubs(:proxy_versions).returns(versions)
       ProxyAPI::Openscap.any_instance.stubs(:validate_scap_content).returns({'errors' => []})
       ProxyAPI::Openscap.any_instance.stubs(:fetch_policies_for_scap_content)
           .returns({'xccdf_org.ssgproject.content_profile_common' => 'Common Profile for General-Purpose Fedora Systems'})
@@ -28,6 +30,8 @@ Spork.each_run do
     def add_smart_proxy
       FactoryGirl.create(:smart_proxy, :url => 'http://localhost:8443', :features => [FactoryGirl.create(:feature, :name => 'Openscap')])
       ::ProxyAPI::Features.any_instance.stubs(:features).returns(%w(puppet openscap))
+      versions = { "version" => "1.11.0", "modules" => { "openscap" => "0.5.3" } }
+      ::ProxyAPI::Version.any_instance.stubs(:proxy_versions).returns(versions)
       ProxyAPI::Openscap.any_instance.stubs(:validate_scap_content).returns({'errors' => []})
       ProxyAPI::Openscap.any_instance.stubs(:fetch_policies_for_scap_content)
           .returns({'xccdf_org.ssgproject.content_profile_common' => 'Common Profile for General-Purpose Fedora Systems'})


### PR DESCRIPTION
1. Even if we skip validation, profiles will not be created and the scap content is irrelevant.
2. While seeding we can not ensure an available proxy.
3. Added to proxy availability its version as we need 0.5.x or higher.