### PR TITLE
Fixes #14478 - Handling exception on search failure

### DIFF
--- a/app/controllers/arf_reports_controller.rb
+++ b/app/controllers/arf_reports_controller.rb
@@ -12,6 +12,8 @@ class ArfReportsController < ApplicationController
     @arf_reports = resource_base.includes(:host => [:policies, :last_report_object, :host_statuses])
       .search_for(params[:search], :order => params[:order])
       .paginate(:page => params[:page], :per_page => params[:per_page])
+  rescue NoMethodError
+    process_error :error_msg => _("Wrong search syntax")
   end
 
   def show

--- a/app/views/arf_reports/_list.html.erb
+++ b/app/views/arf_reports/_list.html.erb
@@ -13,7 +13,11 @@
   <% for arf_report in @arf_reports %>
     <tr>
     <td class="ca">
-          <%= check_box_tag "host_ids[]", nil, false, :id => "host_ids_#{arf_report.id}", :disabled => !authorized?, :class => 'host_select_boxes', :onclick => 'hostChecked(this)' %>
+          <%= check_box_tag "host_ids[]", nil, false,
+                            :id => "host_ids_#{arf_report.id}",
+                            :disabled => !authorized_via_my_scope('arf_reports', 'destroy'),
+                            :class => 'host_select_boxes',
+                            :onclick => 'hostChecked(this)' %>
         </td>
       <td><%= name_column(arf_report.host) %></td>
       <td><%= display_link_if_authorized(_("%s ago") % time_ago_in_words(arf_report.reported_at), hash_for_arf_report_path(:id => arf_report.id)) %></td>


### PR DESCRIPTION
Turns out scoped search utterly fails with `NoMethodError` when there is a malformed query. Also `authorized?` helper did not work for me now for some reason (possibly change in the core).  