### PR TITLE
Resolves the problem with breakdown view on sqlite, fixes tests

### DIFF
--- a/app/models/concerns/foreman_openscap/log_extensions.rb
+++ b/app/models/concerns/foreman_openscap/log_extensions.rb
@@ -3,6 +3,16 @@ module ForemanOpenscap
     extend ActiveSupport::Concern
     included do
       attr_accessible :result
+      SCAP_RESULT = %w(pass fail error unknown notapplicable notchecked notselected informational fixed)
+      validate :scap_result
+    end
+
+    private
+
+    def scap_result
+      if report.is_a? ForemanOpenscap::ArfReport
+        errors.add(:result, _('is not included in SCAP_RESULT')) unless SCAP_RESULT.include? result
+      end
     end
   end
 end

--- a/app/models/foreman_openscap/arf_report.rb
+++ b/app/models/foreman_openscap/arf_report.rb
@@ -6,7 +6,6 @@ module ForemanOpenscap
     include OpenscapProxyExtensions
 
     # attr_accessible :host_id, :reported_at, :status, :metrics
-    RESULT = %w(pass fail error unknown notapplicable notchecked notselected informational fixed)
     METRIC = %w(passed othered failed)
     BIT_NUM = 10
     MAX = (1 << BIT_NUM) - 1
@@ -18,9 +17,6 @@ module ForemanOpenscap
     has_one :asset, :through => :host, :class_name => 'ForemanOpenscap::Asset', :as => :assetable
     after_save :assign_locations_organizations
     has_one :log, :foreign_key => :report_id
-
-    delegate :result, :to => :log, :allow_nil => true
-    validates :result, :inclusion => { :in => RESULT }
 
     delegate :asset=, :to => :host
 

--- a/app/views/arf_reports/_list.html.erb
+++ b/app/views/arf_reports/_list.html.erb
@@ -13,7 +13,13 @@
   <% for arf_report in @arf_reports %>
     <tr>
     <td class="ca">
-          <%= check_box_tag "host_ids[]", nil, false, :id => "host_ids_#{arf_report.id}", :disabled => !authorized?, :class => 'host_select_boxes', :onclick => 'hostChecked(this)' %>
+          <%= check_box_tag "host_ids[]",
+                             nil,
+                             false,
+                             :id => "host_ids_#{arf_report.id}",
+                             :disabled => !authorized_for(:controller => :arf_reports, :action => :destroy),
+                             :class => 'host_select_boxes',
+                             :onclick => 'hostChecked(this)' %>
         </td>
       <td><%= name_column(arf_report.host) %></td>
       <td><%= display_link_if_authorized(_("%s ago") % time_ago_in_words(arf_report.reported_at), hash_for_arf_report_path(:id => arf_report.id)) %></td>

--- a/db/migrate/20150821100137_migrate_from_scaptimony.rb
+++ b/db/migrate/20150821100137_migrate_from_scaptimony.rb
@@ -6,12 +6,13 @@ class MigrateFromScaptimony < ActiveRecord::Migration
       def rename_table_indexes(a,b)
       end
     end
+
+    execute 'DROP VIEW IF EXISTS scaptimony_arf_report_breakdowns'
+    execute 'DROP VIEW IF EXISTS foreman_openscap_arf_report_breakdowns'
+
     ActiveRecord::Base.connection.tables.grep(/^scaptimony/).each do |table|
       rename_table table, table.sub(/^scaptimony/, "foreman_openscap")
     end
-
-    execute 'DROP VIEW scaptimony_arf_report_breakdowns' if table_exists? 'scaptimony_arf_report_breakdowns'
-    execute 'DROP VIEW foreman_openscap_arf_report_breakdowns' if table_exists? 'foreman_openscap_arf_report_breakdowns'
 
     execute <<-SQL
       CREATE VIEW foreman_openscap_arf_report_breakdowns AS
@@ -39,12 +40,12 @@ class MigrateFromScaptimony < ActiveRecord::Migration
   end
 
   def down
+    execute 'DROP VIEW IF EXISTS scaptimony_arf_report_breakdowns'
+    execute 'DROP VIEW IF EXISTS foreman_openscap_arf_report_breakdowns'
+
     ActiveRecord::Base.connection.tables.grep(/^foreman_openscap/).each do |table|
       rename_table table, table.sub(/^foreman_openscap/, "scaptimony")
     end
-
-    execute 'DROP VIEW scaptimony_arf_report_breakdowns' if table_exists? 'scaptimony_arf_report_breakdowns'
-    execute 'DROP VIEW foreman_openscap_arf_report_breakdowns' if table_exists? 'foreman_openscap_arf_report_breakdowns'
 
     execute <<-SQL
       CREATE VIEW scaptimony_arf_report_breakdowns AS


### PR DESCRIPTION
Another attempt to get rid of the errors. Seems like only sqlite had problems during migrations. I did not manage to reproduce locally, but I found out views in sqlite are read-only and cannot be altered. Now there should be no attempts to rename breakdown view and tests should turn green.