### PR TITLE
Fixes #14253 - Avoid mass assignment for policy widgets

### DIFF
--- a/app/helpers/policy_dashboard_helper.rb
+++ b/app/helpers/policy_dashboard_helper.rb
@@ -16,10 +16,6 @@ module PolicyDashboardHelper
     :report_missing => '#92A8CD',
   }
 
-  def policy_widget_list
-    ForemanOpenscap::PolicyDashboard::Manager.widgets
-  end
-
   def host_breakdown_chart(report, options = {})
     data = []
     [[:compliant_hosts, _('Compliant hosts')],
@@ -39,5 +35,14 @@ module PolicyDashboardHelper
       link_to(name, path, :class=>'dashboard-links') +
       content_tag(:h4, @report[label])
     end
+  end
+
+  def compliance_widget(opts)
+    name = opts.delete(:name)
+    template = opts.delete(:template)
+    widget = Widget.new(opts)
+    widget.name = name
+    widget.template = template
+    widget
   end
 end

--- a/app/views/policy_dashboard/index.html.erb
+++ b/app/views/policy_dashboard/index.html.erb
@@ -6,7 +6,7 @@
   <ul>
     <% [{:template => 'policy_status_widget', :sizex => 8, :sizey => 1, :name => N_('Status table')},
         {:template => 'policy_chart_widget', :sizex => 4, :sizey => 1, :name => N_('Status chart')}].each do |w| %>
-      <% widget = Widget.new(w) %>
+      <% widget = compliance_widget(w) %>
       <%= content_tag(:li, widget_data(widget)) do %>
         <div class="widget <%= widget.name.parameterize %>">
           <%= render_widget(widget) %>


### PR DESCRIPTION
I also removed useless helper. We do not even have `ForemanOpenscap::PolicyDashboard::Manager`.