### PR TITLE
Fixes #15365 - Delete reports when cannot find proxy

### DIFF
--- a/app/models/concerns/foreman_openscap/openscap_proxy_extensions.rb
+++ b/app/models/concerns/foreman_openscap/openscap_proxy_extensions.rb
@@ -10,7 +10,7 @@ module ForemanOpenscap
     def openscap_proxy_api
       return @openscap_api if @openscap_api
       proxy_url = openscap_proxy.url if openscap_proxy
-      fail(_("No OpenSCAP proxy found for %s") % id) unless proxy_url
+      raise ::Foreman::Exception.new(N_("No OpenSCAP proxy found for %{class} with %{id}"), { :class => self.class, :id => id }) unless proxy_url
       @openscap_api = ::ProxyAPI::Openscap.new(:url => proxy_url)
     end
   end

--- a/app/models/foreman_openscap/arf_report.rb
+++ b/app/models/foreman_openscap/arf_report.rb
@@ -164,11 +164,13 @@ module ForemanOpenscap
     end
 
     def destroy
-      if openscap_proxy_api.destroy_report(self, ForemanOpenscap::Helper::find_name_or_uuid_by_host(host))
-        super
-      else
-        false
+      begin
+        openscap_proxy_api.destroy_report(self, ForemanOpenscap::Helper::find_name_or_uuid_by_host(host))
+      rescue Foreman::Exception => e
+        logger.error "Failed to delete report with id #{id} from proxy, cause: #{e.message}"
+        logger.debug e.backtrace.join("\n\t")
       end
+      super
     end
 
     def self.newline_to_space(string)

--- a/test/unit/concerns/openscap_proxy_extenstions_test.rb
+++ b/test/unit/concerns/openscap_proxy_extenstions_test.rb
@@ -1,0 +1,21 @@
+require 'test_plugin_helper'
+
+class OpenscapProxyExtensionsTest < ActiveSupport::TestCase
+
+  setup do
+    @host = FactoryGirl.create(:compliance_host)
+  end
+
+  test "should return proxy api for openscap" do
+    arf = FactoryGirl.create(:arf_report,
+                             :host_id => @host.id,
+                             :openscap_proxy => @host.openscap_proxy)
+    api = arf.openscap_proxy_api
+    assert_equal (@host.openscap_proxy.url + "/compliance/"), api.url
+  end
+
+  test "should raise exception when no openscap proxy asociated" do
+    arf = FactoryGirl.create(:arf_report, :host_id => @host.id)
+    assert_raises(Foreman::Exception) { arf.openscap_proxy_api }
+  end
+end


### PR DESCRIPTION
When proxy associated with reports is not available (or was already removed), the reports cannot be deleted because the request to delete a report file on proxy fails. This changes behaviour to 'best effort' - if proxy can be reached, try to do a cleanup, if not, just delete the report from db.