### PR TITLE
Fixes #15676 - defensive migration 

### DIFF
--- a/app/models/concerns/foreman_openscap/openscap_proxy_core_extensions.rb
+++ b/app/models/concerns/foreman_openscap/openscap_proxy_core_extensions.rb
@@ -9,7 +9,7 @@ module ForemanOpenscap
     end
 
     def update_scap_client
-      update_scap_client_params if openscap_proxy_id_changed?
+      update_scap_client_params if changed.include?('openscap_proxy_id')
     end
 
     def update_scap_client_params

--- a/app/models/foreman_openscap/compliance_status.rb
+++ b/app/models/foreman_openscap/compliance_status.rb
@@ -37,6 +37,8 @@ module ForemanOpenscap
     end
 
     def relevant?
+      # May fail host status during migration
+      return false unless ForemanOpenscap::Asset.table_exists?
       host.policies.present?
     end
 


### PR DESCRIPTION
During migration, before compliance turns to foreman_openscap and later migrations
we encounter failures due to not finding 'openscap_proxy_id' and foreman_openscap_assets table.
this code is defending from those failures