### PR TITLE
Fixes #15756 - Respect host name/uuid

### DIFF
--- a/lib/foreman_openscap/data_migration.rb
+++ b/lib/foreman_openscap/data_migration.rb
@@ -64,7 +64,7 @@ module ForemanOpenscap
 
     def fetch_host_name(asset_id)
       asset = ForemanOpenscap::Asset.find(asset_id)
-      asset.host.to_label
+      ForemanOpenscap::Helper.find_name_or_uuid_by_host(asset.host)
     end
 
     def arfs_by_reported(time)

--- a/lib/foreman_openscap/helper.rb
+++ b/lib/foreman_openscap/helper.rb
@@ -16,25 +16,21 @@ module ForemanOpenscap::Helper
   end
 
   def self.find_name_or_uuid_by_host(host)
-    if defined?(::Katello::System)
-      host.content_host.uuid
-    else
-      host.name
-    end
+    (host.respond_to?(:subscription_facet) && !host.subscription_facet.nil?) ? host.subscription_facet.try(:uuid) : host.name
   end
 
   private
 
   def self.find_host_by_name_or_uuid(cname)
-    if defined?(Katello::System)
-      host = Host.includes(:content_host).where(:katello_systems => {:uuid => cname}).first
+    if Facets.registered_facets.keys.include?(:subscription_facet)
+      host = Katello::Host::SubscriptionFacet.find_by_uuid(cname).try(:host)
       host ||= Host.find_by_name(cname)
     else
       host = Host.find_by_name(cname)
     end
+
     unless host
       Rails.logger.error "Could not find Host with name: #{cname}"
-      Rails.logger.error "Please check that Content host is linked to Foreman host" if defined?(Katello::System)
       fail ActiveRecord::RecordNotFound
     end
     host


### PR DESCRIPTION
In migration, we should also respect the
host's uuid (with Katello) or name (without)