### PR TITLE
Refs #16096 - Typo fix

### DIFF
--- a/app/controllers/api/v2/compliance/scap_contents_controller.rb
+++ b/app/controllers/api/v2/compliance/scap_contents_controller.rb
@@ -1,7 +1,7 @@
 module Api::V2
   module Compliance
     class ScapContentsController < ::Api::V2::BaseController
-      include Foreman::Controller::Parameter::ScapContent
+      include Foreman::Controller::Parameters::ScapContent
       before_filter :find_resource, :except => %w(index create)
 
       def resource_name


### PR DESCRIPTION
Typo in `app/controllers/api/v2/compliance/scap_contents_controller.rb`
should be "Parameters" instead of "Parameter"