### PR TITLE
Fixes #16229 - rename foreman to tfm

### DIFF
--- a/app/assets/javascripts/foreman_openscap/policy_edit.js
+++ b/app/assets/javascripts/foreman_openscap/policy_edit.js
@@ -1,7 +1,7 @@
 function scap_content_selected(element){
   var attrs = attribute_hash(['scap_content_id']);
   var url = $(element).attr('data-url');
-  foreman.tools.showSpinner();
+  tfm.tools.showSpinner();
   $.ajax({
     data: attrs,
     type: 'post',


### PR DESCRIPTION
In javascript namespace, we changed from
"foreman" to "tfm"