### PR TITLE
Fixes #16323 - restore widget rendering on policy page

### DIFF
--- a/app/views/policy_dashboard/index.html.erb
+++ b/app/views/policy_dashboard/index.html.erb
@@ -9,7 +9,7 @@
       <% widget = compliance_widget(w) %>
       <%= content_tag(:li, widget_data(widget)) do %>
         <div class="widget <%= widget.name.parameterize %>">
-          <%= render_widget(widget) %>
+          <%= render(:partial => widget.template, :locals => widget.data) %>
         </div>
       <% end %>
     <% end %>


### PR DESCRIPTION
I don't think it makes sense to load data by ajax on this page, therefore I just extracted original method implementation.