### PR TITLE
Fixes #16431: Explicitly set path of PolicyApi include

### DIFF
--- a/app/controllers/concerns/foreman/controller/parameters/policy.rb
+++ b/app/controllers/concerns/foreman/controller/parameters/policy.rb
@@ -1,6 +1,6 @@
 module Foreman::Controller::Parameters::Policy
   extend ActiveSupport::Concern
-  include PolicyApi
+  include Foreman::Controller::Parameters::PolicyApi
 
   class_methods do
     def policy_params_filter


### PR DESCRIPTION
Defining modules with syntax `::` has unintended consequences with
respect to how modules are looked up. This explicitly declares the
full path to the PolicyApi module instead of relying on Ruby to
attempt to automatically determine it.