### PR TITLE
Fixes #17224 - Move empty indexes to use Patterfly style

### DIFF
--- a/app/controllers/policies_controller.rb
+++ b/app/controllers/policies_controller.rb
@@ -99,16 +99,6 @@ class PoliciesController < ApplicationController
     end
   end
 
-  def welcome
-    @searchbar = true
-    if (model_of_controller.first.nil? rescue false)
-      @searchbar = false
-      render :welcome rescue nil and return
-    end
-  rescue
-    not_found
-  end
-
   private
   def find_by_id
     @policy = resource_base.find(params[:id])

--- a/app/controllers/scap_contents_controller.rb
+++ b/app/controllers/scap_contents_controller.rb
@@ -48,16 +48,6 @@ class ScapContentsController < ApplicationController
     end
   end
 
-  def welcome
-    @searchbar = true
-    if (model_of_controller.first.nil? rescue false)
-      @searchbar = false
-      render :welcome rescue nil and return
-    end
-  rescue
-    not_found
-  end
-
   private
   def find_by_id
     @scap_content = resource_base.find(params[:id])

--- a/app/views/policies/welcome.html.erb
+++ b/app/views/policies/welcome.html.erb
@@ -1,15 +1,14 @@
-<% title_actions display_link_if_authorized(_("New Compliance Policy"), hash_for_new_policy_path, :class => "btn btn-default") %>
+<% content_for(:title, _("Compliance Policies")) %>
+<div class="blank-slate-pf">
+  <div class="blank-slate-pf-icon">
+    <%= icon_text("key", "", :kind => "fa") %>
+  </div>
+  <h1><%= _('Compliance Policies') %></h1>
+  <p><%= (_('In Foreman, a compliance policy checklist is defined via %s.') % link_to(_('SCAP content'), scap_contents_path)).html_safe %></br>
+    <%= _('Once SCAP content is present, you can create a policy, assign select host groups and schedule to run.') %>
+  </p>
 
-<% title _("Compliance policy configuration") %>
-<div id="welcome">
-  <p>
-    <%= _('A compliance policy is defined by security professionals who specify desired ' +
-          'settings (often in the form of a checklist) that are to be used in the computing ' +
-          'environment. Compliance audit is a process of figuring out whether a given object ' +
-          'follows all the rules written out in a compliance policy.') %>
-  </p>
-  <p>
-    <%= (_('In Foreman, a compliance policy checklist is defined via %s, once SCAP content ' +
-           'is present, you can create a policy, assign select host groups and schedule to run.') % link_to(_('SCAP content'), scap_contents_path)).html_safe %>
-  </p>
+  <div class="blank-slate-pf-main-action">
+    <%= new_link(_('New Policy'), {}, { :class => "btn-lg" }) %>
+  </div>
 </div>

--- a/app/views/scap_contents/welcome.html.erb
+++ b/app/views/scap_contents/welcome.html.erb
@@ -1,15 +1,16 @@
-<% title_actions display_link_if_authorized(_("New SCAP content"), hash_for_new_scap_content_path, :class => "btn btn-default") %>
+<% content_for(:title, _("SCAP Content")) %>
+<div class="blank-slate-pf">
+  <div class="blank-slate-pf-icon">
+    <%= icon_text("key", "", :kind => "fa") %>
+  </div>
+  <h1><%= _('SCAP Content') %></h1>
+  <p><%= _('The Security Content Automation Protocol (SCAP), combines a number of open standards that are used to enumerate software flaws and
+        configuration issues related to security. ') %></br>
+    <%= (_('In Foreman, scap_contents represent the SCAP security guides on your hosts, and create SCAP profiles for you to assign to hosts / host groups
+    via %s') % link_to('compliance policies', policies_path)).html_safe %>
+  </p>
 
-<% title _("SCAP content configuration") %>
-<div id="welcome">
-  <p>
-  <%= _('The Security Content Automation Protocol (SCAP), combines a number of open standards that are used to enumerate software flaws and
-        configuration issues related to security. They measure systems to find vulnerabilities and offer methods to score those findings in order
-        to evaluate the possible impact. It is a method for using those open standards for automated vulnerability management, measurement,
-        and policy compliance evaluation. ') %><small><%= (_('Source: Wikipedia %s') % link_to(_('read more'), 'http://en.wikipedia.org/wiki/Security_Content_Automation_Protocol')).html_safe %></small>
-  </p>
-  <p>
-    <%= (_("In Foreman, scap_contents represent the SCAP security guides on your hosts, and create SCAP profiles for you to assign to hosts / host groups
-          via %s") % link_to('compliance policies', policies_path)).html_safe %>
-  </p>
+  <div class="blank-slate-pf-main-action">
+    <%= new_link(_('New SCAP Content'), {}, { :class => "btn-lg" }) %>
+  </div>
 </div>


### PR DESCRIPTION
Both scap_contents and policies empty index (welcome),
now uses Paterfly style