### PR TITLE
Fixes #18207 - Disable tailoring feature for old proxies

### DIFF
--- a/app/controllers/api/v2/compliance/tailoring_files_controller.rb
+++ b/app/controllers/api/v2/compliance/tailoring_files_controller.rb
@@ -3,6 +3,7 @@ module Api::V2
     class TailoringFilesController < ::Api::V2::BaseController
       include Foreman::Controller::Parameters::TailoringFile
       before_filter :find_resource, :except => %w(index create)
+      before_filter :openscap_proxy_check, :only => %w(create)
 
       def resource_name
         '::ForemanOpenscap::TailoringFile'
@@ -77,6 +78,13 @@ module Api::V2
           :view
         else
           super
+        end
+      end
+
+      def openscap_proxy_check
+        unless ForemanOpenscap::TailoringFile.any?
+          check = ForemanOpenscap::OpenscapProxyVersionCheck.new.run
+          render_error :custom_error, :status => :unprocessable_entity, :locals => { :message => check.message } unless check.pass?
         end
       end
     end

--- a/app/helpers/tailoring_files_helper.rb
+++ b/app/helpers/tailoring_files_helper.rb
@@ -1,0 +1,5 @@
+module TailoringFilesHelper
+  def run_tailoring_proxy_check
+    ForemanOpenscap::OpenscapProxyVersionCheck.new.run
+  end
+end

--- a/app/services/foreman_openscap/openscap_proxy_version_check.rb
+++ b/app/services/foreman_openscap/openscap_proxy_version_check.rb
@@ -1,0 +1,63 @@
+module ForemanOpenscap
+  class OpenscapProxyVersionCheck
+
+    def initialize
+      @versions = {}
+      @message = ''
+      @down = []
+    end
+
+    def run
+      @versions = openscap_proxy_versions.select do |key, value|
+        Gem::Version.new(value) <= Gem::Version.new("0.6.1")
+      end
+      self
+    end
+
+    def pass?
+      !any_outdated? && !any_unreachable?
+    end
+
+    def any_outdated?
+      !@versions.empty?
+    end
+
+    def any_unreachable?
+      !@down.empty?
+    end
+
+    def message
+      if pass?
+        @message
+      else
+        build_message
+      end
+    end
+
+    private
+
+    def build_message
+      @message = _('This feature is temporarily disabled. ')
+      @message << _('The following Smart Proxies need to be updated to unlock the feature: %s. ') % @versions.keys.to_sentence if any_outdated?
+      @message << _('The following proxies could not be reached: %s. Please make sure they are available so Foreman can check their versions.') % @down.to_sentence if any_unreachable?
+      @message
+    end
+
+    def get_openscap_proxies
+      SmartProxy.with_features "Openscap"
+    end
+
+    def openscap_proxy_versions
+      get_openscap_proxies.inject({}) do |memo, proxy|
+        begin
+          status = ProxyStatus::Version.new(proxy).version
+          openscap_version = status["modules"]["openscap"]
+          memo[proxy.name] = openscap_version
+        rescue Foreman::WrappedException
+          @down << proxy.name
+        end
+        memo
+      end
+    end
+  end
+end

--- a/app/views/tailoring_files/welcome.html.erb
+++ b/app/views/tailoring_files/welcome.html.erb
@@ -8,8 +8,14 @@
     <%= (_('In Foreman, tailoring_files represent the custom modifications to default XCCDF profiles and they can be applied to hosts
     via %s') % link_to('compliance policies', policies_path)).html_safe %>
   </p>
-
+  <% proxy_check = run_tailoring_proxy_check %>
   <div class="blank-slate-pf-main-action">
-    <%= new_link(_('New Tailoring File'), {}, { :class => "btn-lg" }) %>
+    <%= new_link(_('New Tailoring File'), {}, { :class => "btn-lg", :disabled => !proxy_check.pass? }) %>
   </div>
+
+  <p>
+  <% unless proxy_check.pass? %>
+    <%= alert :class => 'alert-warning', :header => '', :text => proxy_check.message.html_safe %>
+  <% end %>
+  </p>
 </div>

--- a/test/functional/api/v2/compliance/tailoring_files_controller_test.rb
+++ b/test/functional/api/v2/compliance/tailoring_files_controller_test.rb
@@ -25,6 +25,8 @@ class Api::V2::Compliance::TailoringFilesControllerTest < ActionController::Test
   test "should create tailoring_file" do
     tf = FactoryGirl.build(:tailoring_file)
     tf_params = { :name => tf.name, :original_filename => tf.original_filename, :scap_file => tf.scap_file }
+    ForemanOpenscap::OpenscapProxyVersionCheck.any_instance.stubs(:openscap_proxy_versions).
+      returns({})
     post :create, tf_params, set_session_user
     assert_response :success
   end
@@ -48,5 +50,14 @@ class Api::V2::Compliance::TailoringFilesControllerTest < ActionController::Test
     delete :destroy, { :id => tailoring_file.id }, set_session_user
     assert_response :ok
     refute ForemanOpenscap::ScapContent.exists?(tailoring_file.id)
+  end
+
+  test "should not create tailoring file when there is outdated proxy version" do
+    tf = FactoryGirl.build(:tailoring_file)
+    tf_params = { :name => tf.name, :original_filename => tf.original_filename, :scap_file => tf.scap_file }
+    ForemanOpenscap::OpenscapProxyVersionCheck.any_instance.stubs(:openscap_proxy_versions).
+      returns('test-proxy' => '0.5.4')
+    post :create, tf_params, set_session_user
+    assert_response :unprocessable_entity
   end
 end

--- a/test/unit/services/tailoring_files_proxy_check_test.rb
+++ b/test/unit/services/tailoring_files_proxy_check_test.rb
@@ -1,0 +1,27 @@
+require 'test_plugin_helper'
+
+class TailoringFilesProxyCheckTest < ActiveSupport::TestCase
+  test 'should find proxies with old versions' do
+    ForemanOpenscap::OpenscapProxyVersionCheck.any_instance.stubs(:openscap_proxy_versions).
+      returns('old-proxy.test.com' => "0.5.4", "outdate-proxy.test.com" => "0.6.0")
+    check = ForemanOpenscap::OpenscapProxyVersionCheck.new.run
+    refute check.pass?
+    refute check.message.empty?
+  end
+
+  test 'should not find any outdated proxies' do
+    ForemanOpenscap::OpenscapProxyVersionCheck.any_instance.stubs(:openscap_proxy_versions).
+      returns({})
+    check = ForemanOpenscap::OpenscapProxyVersionCheck.new.run
+    assert check.pass?
+    assert check.message.empty?
+  end
+
+  test 'should fail when proxy cannot be reached' do
+    ProxyStatus::Version.any_instance.stubs(:version).raises(Foreman::WrappedException.new(nil, 'test message'))
+    ForemanOpenscap::OpenscapProxyVersionCheck.any_instance.stubs(:get_openscap_proxies).returns([FactoryGirl.create(:openscap_proxy)])
+    check = ForemanOpenscap::OpenscapProxyVersionCheck.new.run
+    refute check.pass?
+    refute check.message.empty?
+  end
+end


### PR DESCRIPTION
I tried to make this as simple as possible. Behavior:

Tailoring files are disabled in UI (you can't create one) if there is a proxy with 'Openscap' feature and version is lower than required. If any of the openscap proxies is down, user is asked to make them available so that foreman can check the version. After the check passes, the feature is enabled.

~~API and CLI only checks if proxies have required versions when creating a tailoring file and ignores those that are down. Require all openscap proxies to be up when creating a tailoring file seems too harsh. I plan to add a warning banner to hammer.~~

API will check when there are no tailoring files as per today's lunch discussion.

