### PR TITLE
Fixes #18837 - Delete reports when host is missing

### DIFF
--- a/app/models/foreman_openscap/arf_report.rb
+++ b/app/models/foreman_openscap/arf_report.rb
@@ -164,11 +164,15 @@ module ForemanOpenscap
     end
 
     def destroy
-      begin
-        openscap_proxy_api.destroy_report(self, ForemanOpenscap::Helper::find_name_or_uuid_by_host(host))
-      rescue Foreman::Exception => e
-        logger.error "Failed to delete report with id #{id} from proxy, cause: #{e.message}"
-        logger.debug e.backtrace.join("\n\t")
+      if host
+        begin
+          openscap_proxy_api.destroy_report(self, ForemanOpenscap::Helper::find_name_or_uuid_by_host(host))
+        rescue Foreman::Exception => e
+          logger.error "Failed to delete report with id #{id} from proxy, cause: #{e.message}"
+          logger.debug e.backtrace.join("\n\t")
+        end
+      else
+        logger.error "Failed to delete report with id #{id} from proxy, no host associated with report"
       end
       super
     end


### PR DESCRIPTION
I could not reproduce this issue because all reports get [deleted with host](https://github.com/theforeman/foreman/blob/develop/app/models/host/managed.rb#L21). I am not sure how this problem can even happen because reports have foreign key constraint on host_id in db. Anyway, this should delete the reports and and avoid a crash.