### PR TITLE
Fixes #18841 - Added policies to hosts index api scope

### DIFF
--- a/lib/foreman_openscap/engine.rb
+++ b/lib/foreman_openscap/engine.rb
@@ -161,6 +161,14 @@ module ForemanOpenscap
                                           :host_action_button => true,
                                           :provided_inputs => "policies")
         end
+
+        add_controller_action_scope(::Api::V2::HostsController, :index) do |base_scope|
+          base_scope.includes(:policies)
+        end
+
+        add_controller_action_scope(::HostsController, :index) do |base_scope|
+          base_scope.includes(:policies)
+        end
       end
     end
 


### PR DESCRIPTION
Policies are loaded while calculating compliance status. To avoid N+1 query, we are preloading them.