### PR TITLE
fixes #19164 - create feature even if on older rex

### DIFF
--- a/lib/foreman_openscap/engine.rb
+++ b/lib/foreman_openscap/engine.rb
@@ -157,11 +157,17 @@ module ForemanOpenscap
         parameter_filter Hostgroup, :openscap_proxy_id, :openscap_proxy
         parameter_filter Log, :result
 
-        if ForemanOpenscap.with_remote_execution? && Gem::Version.new(ForemanRemoteExecution::VERSION) >= Gem::Version.new('1.2.3')
-          RemoteExecutionFeature.register(:foreman_openscap_run_scans, N_("Run OpenSCAP scan"),
-                                          :description => N_("Run OpenSCAP scan"),
-                                          :host_action_button => true,
-                                          :provided_inputs => "policies")
+        if ForemanOpenscap.with_remote_execution?
+          options = {
+            :description => N_("Run OpenSCAP scan"),
+            :provided_inputs => "policies"
+          }
+
+          if Gem::Version.new(ForemanRemoteExecution::VERSION) >= Gem::Version.new('1.2.3')
+            options[:host_action_button] = true
+          end
+
+          RemoteExecutionFeature.register(:foreman_openscap_run_scans, N_("Run OpenSCAP scan"), options)
         end
 
         add_controller_action_scope(::Api::V2::HostsController, :index) do |base_scope|


### PR DESCRIPTION
The template references the feature, so it always needs to exist.