### PR TITLE
Refs #19562 - Avoid clash with core's factories

### DIFF
--- a/test/factories/compliance_host_factory.rb
+++ b/test/factories/compliance_host_factory.rb
@@ -4,8 +4,8 @@ FactoryGirl.define do
   end
 
   factory :openscap_proxy, :class => SmartProxy do
-    sequence(:name) { |n| "proxy#{n}" }
-    sequence(:url) { |n| "https://somewhere#{n}.net:8443" }
+    sequence(:name) { |n| "openscap_proxy#{n}" }
+    sequence(:url) { |n| "https://anywhere#{n}.net:8443" }
     features { |sp| [sp.association(:openscap_feature)] }
   end
 


### PR DESCRIPTION
I managed to get the same error locally when running tests multiple times. The errors we saw on Jenkins were all caused by openscap_proxy factory, so maybe it somehow clashes with the factory from core. I changed the proxy test data to be different and run tests locally 30 times without an error.