### PR TITLE
Fixes #20886 - Do not call to proxy when ds content not changed

### DIFF
--- a/app/lib/proxy_api/available_proxy.rb
+++ b/app/lib/proxy_api/available_proxy.rb
@@ -7,7 +7,8 @@ module ::ProxyAPI
       Net::HTTPBadResponse,
       Net::HTTPHeaderSyntaxError,
       Net::ProtocolError,
-      Timeout::Error
+      Timeout::Error,
+      ProxyAPI::ProxyException
     ].freeze
 
     def initialize(args)

--- a/app/models/concerns/foreman_openscap/data_stream_content.rb
+++ b/app/models/concerns/foreman_openscap/data_stream_content.rb
@@ -10,7 +10,7 @@ module ForemanOpenscap
 
       validates_with ForemanOpenscap::DataStreamValidator
 
-      after_save :create_profiles
+      after_save :create_profiles, :if => lambda { |ds_content| ds_content.scap_file_changed? }
 
       before_validation :redigest, :if => lambda { |ds_content| ds_content.persisted? && ds_content.scap_file_changed? }
       before_destroy ActiveRecord::Base::EnsureNotUsedBy.new(:policies)


### PR DESCRIPTION
The reasoning behind this is that if no new file is uploaded, then there will be no change in profiles and therefore we do not need openscap proxy to be online when we only update other attributes.