### PR TITLE
Fixed remaining cops

### DIFF
--- a/app/helpers/policies_helper.rb
+++ b/app/helpers/policies_helper.rb
@@ -88,7 +88,7 @@ module PoliciesHelper
   end
 
   def previous_link(form)
-    previous = content_tag(:span, :class => 'glyphicon glyphicon-chevron-left') {}
+    previous = content_tag(:span, :class => 'glyphicon glyphicon-chevron-left')
     content_tag(:div, :class => 'pull-left') do
       link_to(previous.html_safe, '#', :class => 'btn btn-default', :onclick => "previous_step('#{@policy.previous_step}')")
     end

--- a/test/factories/arf_report_factory.rb
+++ b/test/factories/arf_report_factory.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
     sequence(:created_at) { |n| Time.new(1490 + n, 0o1, 13, 15, 24, 0o0) }
     logs []
     status 0
-    metrics {}
+    metrics({})
     openscap_proxy nil
   end
 end


### PR DESCRIPTION
spaces left of `{` fail in jenkins