### PR TITLE
Fixes #23259 - Fix resource switcher for breadcrumbs

### DIFF
--- a/app/helpers/arf_reports_helper.rb
+++ b/app/helpers/arf_reports_helper.rb
@@ -13,6 +13,19 @@ module ArfReportsHelper
     end
   end
 
+  def arf_report_breadcrumbs
+    if @arf_report && @arf_report.host
+      breadcrumbs(:resource_url => api_compliance_arf_reports_path,
+                  :switchable => false,
+                  :items => [
+                    { :caption => _('Compliance Reports'),
+                      :url => url_for(arf_reports_path) },
+                    { :caption => @arf_report.host.name,
+                      :url => (arf_report_path(@arf_report) if authorized_for(hash_for_arf_report_path(@arf_report))) }
+                  ])
+    end
+  end
+
   def result_tag(level)
     tag = case level
           when 'pass'

--- a/app/views/arf_reports/show.html.erb
+++ b/app/views/arf_reports/show.html.erb
@@ -3,6 +3,7 @@
 <% stylesheet 'foreman_openscap/reports' %>
 
 <% title "#{@arf_report.host}" %>
+<%= arf_report_breadcrumbs %>
 
 <p class='ra'><%= reported_info @arf_report %></p>
 

--- a/app/views/arf_reports/show_html.html.erb
+++ b/app/views/arf_reports/show_html.html.erb
@@ -1,4 +1,7 @@
 <%= javascript 'foreman_openscap/load_report'%>
+
+<%= arf_report_breadcrumbs %>
+
 <div class="row">
   <div id="loading">
     <div class="col-md-4"></div>

--- a/app/views/policies/edit.html.erb
+++ b/app/views/policies/edit.html.erb
@@ -1,2 +1,13 @@
 <% title _("Edit Compliance Policy") %>
+<%= breadcrumbs(:resource_url => api_compliance_policies_path,
+                :items => [
+                  { :caption => _('Policies'),
+                    :url => url_for(policies_path)
+                  },
+                  { :caption => @policy.name,
+                    :url => (edit_policy_path(@policy) if authorized_for(hash_for_edit_policy_path(@policy)))
+                  }
+                ]
+              ) if @policy %>
+
 <%= render :partial => "form" %>

--- a/app/views/scap_contents/edit.html.erb
+++ b/app/views/scap_contents/edit.html.erb
@@ -1,3 +1,15 @@
 <% title _("Edit SCAP Content") %>
+<%= breadcrumbs(:resource_url => api_compliance_scap_contents_path,
+                :name_field => 'title',
+                :items => [
+                  { :caption => _('Scap Contents'),
+                    :url => url_for(scap_contents_path)
+                  },
+                  { :caption => @scap_content.title,
+                    :url => (edit_scap_content_path(@scap_content) if authorized_for(hash_for_edit_scap_content_path(@scap_content)))
+                  }
+                ]
+              ) if @scap_content %>
+
 
 <%= render :partial => 'form' %>

--- a/app/views/tailoring_files/edit.html.erb
+++ b/app/views/tailoring_files/edit.html.erb
@@ -1,3 +1,13 @@
 <% title _("Edit Tailoring File") %>
+<%= breadcrumbs(:resource_url => api_compliance_tailoring_files_path,
+                :items => [
+                  { :caption => _('Tailoring Files'),
+                    :url => url_for(tailoring_files_path)
+                  },
+                  { :caption => @tailoring_file.name,
+                    :url => (edit_tailoring_file_path(@tailoring_file) if authorized_for(hash_for_edit_tailoring_file_path(@tailoring_file)))
+                  }
+                ]
+              ) if @tailoring_file %>
 
 <%= render :partial => 'form' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -56,9 +56,9 @@ Rails.application.routes.draw do
     resources :hosts, :only => [:show], :as => :compliance_hosts, :controller => :compliance_hosts
   end
 
-  namespace :api do
+  namespace :api, :defaults => { :format => 'json' } do
     scope "(:apiv)", :module => :v2, :defaults => { :apiv => 'v2' },
-                     :apiv => /v1|v2/, :constraints => ApiConstraints.new(:version => 2) do
+                     :apiv => /v1|v2/, :constraints => ApiConstraints.new(:version => 2, :default => true) do
       namespace :compliance do
         resources :scap_contents, :except => %i[new edit] do
           member do


### PR DESCRIPTION
I am not entirely sure what we should display in breadcrumbs for arf report, I left the hostname there.