### PR TITLE
Fixes #24065 - Handle missing arf file gracefully

### DIFF
--- a/app/controllers/arf_reports_controller.rb
+++ b/app/controllers/arf_reports_controller.rb
@@ -25,7 +25,7 @@ class ArfReportsController < ApplicationController
     begin
       self.response_body = @arf_report.to_html
     rescue => e
-      render :text => _(e.message)
+      render :plain => _(e.message)
     end
   end
 


### PR DESCRIPTION
:text was removed in Rails 5.1