### PR TITLE
Fixes #24509 - add table action headers

### DIFF
--- a/app/views/arf_reports/_list.html.erb
+++ b/app/views/arf_reports/_list.html.erb
@@ -10,7 +10,7 @@
     <th><%= sort :compliance_passed, :as => _("Passed") %></th>
     <th><%= sort :compliance_failed, :as => _("Failed") %></th>
     <th><%= sort :compliance_othered, :as => _("Other") %></th>
-    <th></th>
+    <th><%= _("Actions") %></th>
   </tr>
   <% for arf_report in @arf_reports %>
     <tr>

--- a/app/views/policies/_list.html.erb
+++ b/app/views/policies/_list.html.erb
@@ -5,7 +5,7 @@
     <th><%= _('Profile') %></th>
     <th><%= _('Tailoring File') %></th>
     <th><%= _('Effective Profile') %></th>
-    <th></th>
+    <th><%= _('Actions') %></th>
   </tr>
   <% for policy in @policies %>
     <tr>

--- a/app/views/policy_dashboard/_policy_reports.html.erb
+++ b/app/views/policy_dashboard/_policy_reports.html.erb
@@ -5,7 +5,7 @@
     <th><%= _("Passed") %></th>
     <th><%= _("Failed") %></th>
     <th><%= _("Other") %></th>
-    <th></th>
+    <th><%= _('Actions') %></th>
   </tr>
   <% for arf_report in @policy.arf_reports.latest %>
     <tr>

--- a/app/views/scap_contents/_list.html.erb
+++ b/app/views/scap_contents/_list.html.erb
@@ -3,7 +3,7 @@
     <th class="col-md-4">Title</th>
     <th class="col-md-4">Filename</th>
     <th class="col-md-3">Created</th>
-    <th class="col-md-1"></th>
+    <th class="col-md-1"><%= _('Actions') %></th>
   </tr>
   <% for content in @contents %>
     <tr>

--- a/app/views/tailoring_files/_list.html.erb
+++ b/app/views/tailoring_files/_list.html.erb
@@ -3,7 +3,7 @@
     <th class="col-md-4"><%= _('Name')%></th>
     <th class="col-md-4"><%= _('Filename') %></th>
     <th class="col-md-3"><%= _('Created') %></th>
-    <th class="col-md-1"></th>
+    <th class="col-md-1"><%= _('Actions') %></th>
   </tr>
   <% @tailoring_files.each do |file| %>
     <tr>


### PR DESCRIPTION
The word Actions which is used also in another table headers in foreman, after this correction it will be possible to use the word Actions instead of sixth table header cell.