### PR TITLE
Fixes #24696 - use string for :class_name attributes

### DIFF
--- a/app/models/foreman_openscap/policy.rb
+++ b/app/models/foreman_openscap/policy.rb
@@ -9,7 +9,7 @@ module ForemanOpenscap
     belongs_to :scap_content
     belongs_to :scap_content_profile
     belongs_to :tailoring_file
-    belongs_to :tailoring_file_profile, :class_name => ForemanOpenscap::ScapContentProfile
+    belongs_to :tailoring_file_profile, :class_name => 'ForemanOpenscap::ScapContentProfile'
     has_many :policy_arf_reports
     has_many :arf_reports, :through => :policy_arf_reports, :dependent => :destroy
     has_many :asset_policies

--- a/app/models/foreman_openscap/scap_content_profile.rb
+++ b/app/models/foreman_openscap/scap_content_profile.rb
@@ -3,6 +3,6 @@ module ForemanOpenscap
     belongs_to :scap_content
     has_many :policies
     belongs_to :tailoring_file
-    has_many :tailoring_file_policies, :class_name => ForemanOpenscap::Policy
+    has_many :tailoring_file_policies, :class_name => 'ForemanOpenscap::Policy'
   end
 end


### PR DESCRIPTION
Since Rails 5.2, passing class to `:class_name` is not allowed anymore.