### PR TITLE
Fixes #24719 - Override params for puppet class

### DIFF
--- a/app/models/foreman_openscap/policy.rb
+++ b/app/models/foreman_openscap/policy.rb
@@ -253,19 +253,41 @@ module ForemanOpenscap
         return false
       end
 
-      unless policies_param = puppetclass.class_params.find_by(key: POLICIES_CLASS_PARAMETER)
-        errors[:base] << _("Puppet class %{class} does not have %{parameter} class parameter.") % { :class => SCAP_PUPPET_CLASS, :parameter => POLICIES_CLASS_PARAMETER }
-        return false
+      return false unless override_policies_param(puppetclass)
+      return false unless override_port_param(puppetclass)
+      return false unless override_server_param(puppetclass)
+    end
+
+    def override_policies_param(puppetclass)
+      override_param(puppetclass, POLICIES_CLASS_PARAMETER) do |param|
+        param.key_type      = 'array'
+        param.default_value = '<%= @host.policies_enc %>'
+      end
+    end
+
+    def override_port_param(puppetclass)
+      override_param puppetclass, PORT_CLASS_PARAMETER
+    end
+
+    def override_server_param(puppetclass)
+      override_param puppetclass, SERVER_CLASS_PARAMETER
+    end
+
+    def override_param(puppetclass, param_name)
+      unless param = puppetclass.class_params.find_by(key: param_name)
+        errors[:base] << _("Puppet class %{class} does not have %{parameter} class parameter.") % { :class => SCAP_PUPPET_CLASS, :parameter => param_name }
+        return
       end
 
-      policies_param.override      = true
-      policies_param.key_type      = 'array'
-      policies_param.default_value = '<%= @host.policies_enc %>'
+      param.override = true
 
-      if policies_param.changed? && !policies_param.save
-        errors[:base] << _("%{parameter} class parameter for class %{class} could not be configured.") % { :class => SCAP_PUPPET_CLASS, :parameter => POLICIES_CLASS_PARAMETER }
-        return false
+      yield param if block_given?
+
+      if param.changed? && !param.save
+        errors[:base] << _("%{parameter} class parameter for class %{class} could not be configured.") % { :class => SCAP_PUPPET_CLASS, :parameter => param_name }
+        return
       end
+      param
     end
 
     def cron_line_split

--- a/test/unit/puppet_overrides_test.rb
+++ b/test/unit/puppet_overrides_test.rb
@@ -1,0 +1,38 @@
+require 'test_plugin_helper'
+
+class PuppetOverridesTest < ActiveSupport::TestCase
+  setup do
+    ForemanOpenscap::ScapContent.any_instance.stubs(:fetch_profiles).returns({ 'test_profile_key' => 'test_profile_title' })
+    @scap_content = FactoryBot.create(:scap_content)
+    @scap_profile = FactoryBot.create(:scap_content_profile, :scap_content => @scap_content)
+  end
+
+  test "should override puppet class parameters" do
+    env = FactoryBot.create(:environment)
+    puppet_class = FactoryBot.create(:puppetclass, :name => 'foreman_scap_client')
+    server_param = FactoryBot.create(:puppetclass_lookup_key, :key => 'server')
+    port_param = FactoryBot.create(:puppetclass_lookup_key, :key => 'port')
+    policies_param = FactoryBot.create(:puppetclass_lookup_key, :key => 'policies')
+    FactoryBot.create(:environment_class,
+                      :puppetclass_id => puppet_class.id,
+                      :environment_id => env.id,
+                      :puppetclass_lookup_key_id => server_param.id)
+    FactoryBot.create(:environment_class,
+                      :puppetclass_id => puppet_class.id,
+                      :environment_id => env.id,
+                      :puppetclass_lookup_key_id => port_param.id)
+    FactoryBot.create(:environment_class,
+                      :puppetclass_id => puppet_class.id,
+                      :environment_id => env.id,
+                      :puppetclass_lookup_key_id => policies_param.id)
+    refute server_param.override
+    refute port_param.override
+    refute policies_param.override
+    FactoryBot.create(:policy, :scap_content => @scap_content, :scap_content_profile => @scap_content_profile)
+
+    assert server_param.reload.override
+    assert port_param.reload.override
+    assert policies_param.reload.override
+    assert_equal '<%= @host.policies_enc %>', policies_param.default_value
+  end
+end


### PR DESCRIPTION
Since #24355 was introduced in core, the parameters
are no longer marked for override on import, so we need
to do it ourselves.