### PR TITLE
Fixes #21127 - Skip logging arf-report body

### DIFF
--- a/app/controllers/api/v2/compliance/scap_contents_controller.rb
+++ b/app/controllers/api/v2/compliance/scap_contents_controller.rb
@@ -2,6 +2,7 @@ module Api::V2
   module Compliance
     class ScapContentsController < ::Api::V2::BaseController
       include Foreman::Controller::Parameters::ScapContent
+      include ForemanOpenscap::BodyLogExtensions
       before_action :find_resource, :except => %w[index create]
 
       def resource_name
@@ -19,7 +20,7 @@ module Api::V2
         @scap_contents = resource_scope_for_index(:permission => :view_scap_contents)
       end
 
-      api :GET, '/compliance/scap_contents/:id/xml', N_('Show an SCAP content as XML')
+      api :GET, '/compliance/scap_contents/:id/xml', N_('Download an SCAP content as XML')
       param :id, :identifier, :required => true
 
       def xml

--- a/app/controllers/api/v2/compliance/tailoring_files_controller.rb
+++ b/app/controllers/api/v2/compliance/tailoring_files_controller.rb
@@ -2,6 +2,7 @@ module Api::V2
   module Compliance
     class TailoringFilesController < ::Api::V2::BaseController
       include Foreman::Controller::Parameters::TailoringFile
+      include ForemanOpenscap::BodyLogExtensions
       before_action :find_resource, :except => %w[index create]
       before_action :openscap_proxy_check, :only => %w[create]
 
@@ -20,7 +21,7 @@ module Api::V2
         @tailoring_files = resource_scope_for_index(:permission => :view_tailoring_files)
       end
 
-      api :GET, '/compliance/tailoring_files/:id/xml', N_('Show a Tailoring file as XML')
+      api :GET, '/compliance/tailoring_files/:id/xml', N_('Download a Tailoring file as XML')
       param :id, :identifier, :required => true
 
       def xml

--- a/app/controllers/concerns/foreman_openscap/body_log_extensions.rb
+++ b/app/controllers/concerns/foreman_openscap/body_log_extensions.rb
@@ -1,0 +1,18 @@
+module ForemanOpenscap
+  module BodyLogExtensions
+    extend ActiveSupport::Concern
+
+    def log_response_body
+      return super unless skip_body_log.include?(action_name)
+      logger.debug { logger_msg }
+    end
+
+    def skip_body_log
+      ['xml']
+    end
+
+    def logger_msg
+      "Logging response body of #{response.body.length} characters skipped when downloading DS files"
+    end
+  end
+end

--- a/lib/foreman_openscap/engine.rb
+++ b/lib/foreman_openscap/engine.rb
@@ -40,6 +40,10 @@ module ForemanOpenscap
       Apipie.configuration.checksum_path += ['/compliance/']
     end
 
+    initializer 'foreman_openscap.filter_report_body' do |app|
+      app.config.filter_parameters << :logs if app.config.filter_parameters
+    end
+
     initializer 'foreman_openscap.register_plugin', :before => :finisher_hook do |app|
       Foreman::Plugin.register :foreman_openscap do
         requires_foreman '>= 1.18'


### PR DESCRIPTION
The logging of response body is skipped for downloading scap content and tailoring file via API. The report logs are filtered out when proxy uploads new report. The only questions is whether we should rename `:logs` to something more specific like `:openscap_logs` to make sure the newly added filter does not get applied for other requests as well.