### PR TITLE
Fixes #24608 - Policy dashboard shows unassigned hosts

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -55,7 +55,7 @@ Lint/NonLocalExitFromIterator:
 Lint/UnusedBlockArgument:
   Enabled: false
 
-# Offense count: 30
+# Offense count: 34
 # Cop supports --auto-correct.
 # Configuration parameters: AllowUnusedKeywordArguments, IgnoreEmptyMethods.
 Lint/UnusedMethodArgument:
@@ -186,7 +186,7 @@ Style/Lambda:
 Style/MixinUsage:
   Enabled: false
 
-# Offense count: 1
+# Offense count: 2
 Style/MultipleComparison:
   Enabled: false
 

--- a/app/helpers/policy_dashboard_helper.rb
+++ b/app/helpers/policy_dashboard_helper.rb
@@ -34,4 +34,27 @@ module PolicyDashboardHelper
     widget.template = template
     widget
   end
+
+  def assigned_icon(policy, arf_report)
+    if arf_report.host.combined_policies.include? policy
+      icon = 'check'
+      tooltip_text = _('Host is assigned to policy')
+    else
+      icon = 'close'
+      tooltip_text = _('Host is not assigned to policy but reports were found. You may want to delete the reports or assign the policy again.')
+    end
+    trunc_with_tooltip icon_text(icon, '', :kind => 'fa'), 32, tooltip_text, false
+  end
+
+  def unassigned_hosts_link
+    trunc_with_tooltip(
+      link_to(
+        _("Hosts no longer assigned: %s") % @report[:unassigned_hosts],
+        hosts_path(:search => "removed_from_policy = \"#{@policy.name}\"")
+      ),
+      32,
+      _("Total hosts with reports where policy is no longer assigned."),
+      false
+    )
+  end
 end

--- a/app/mailers/foreman_openscap/policy_mailer.rb
+++ b/app/mailers/foreman_openscap/policy_mailer.rb
@@ -7,7 +7,7 @@ module ForemanOpenscap
 
       @policies = ::ForemanOpenscap::Policy.all.reject { |policy| policy.assets.map(&:host).compact.empty? }
       @compliant_hosts = @policies.map { |policy| Host.comply_with policy }.flatten
-      @incompliant_hosts = @policies.map { |policy| Host.incomply_with policy }.flatten
+      @incompliant_hosts = @policies.map { |policy| Host.not_comply_with policy }.flatten
       changed_hosts_of_policies(@policies)
 
       if user.nil? || user.mail.nil?

--- a/app/services/foreman_openscap/policy_dashboard/data.rb
+++ b/app/services/foreman_openscap/policy_dashboard/data.rb
@@ -18,14 +18,13 @@ module ForemanOpenscap::PolicyDashboard
     end
 
     def fetch_data
-      assigned_count = Host::Managed.assigned_to_policy(@policy).count
       report.update(
         { :compliant_hosts => Host::Managed.comply_with(@policy).count,
-          :incompliant_hosts => Host::Managed.incomply_with(@policy).count,
+          :incompliant_hosts => Host::Managed.not_comply_with(@policy).count,
           :inconclusive_hosts => Host::Managed.inconclusive_with(@policy).count,
           :report_missing => Host::Managed.policy_reports_missing(@policy).count,
-          :assigned_hosts => assigned_count,
-          :unassigned_hosts => hosts.count - assigned_count }
+          :assigned_hosts => Host::Managed.assigned_to_policy(@policy).count,
+          :unassigned_hosts => Host::Managed.removed_from_policy(@policy).count }
       )
     end
   end

--- a/app/views/policy_dashboard/_policy_reports.html.erb
+++ b/app/views/policy_dashboard/_policy_reports.html.erb
@@ -4,15 +4,17 @@
   <table class="<%= table_css_classes('ellipsis') %>">
     <tr>
       <th><%= _('Host') %></th>
+      <th><%= _('Policy assigned') %></th>
       <th><%= _("Date") %></th>
       <th><%= _("Passed") %></th>
       <th><%= _("Failed") %></th>
       <th><%= _("Other") %></th>
       <th><%= _('Actions') %></th>
     </tr>
-    <% @latest_reports.each do |arf_report| %>
+    <% @policy.arf_reports.latest.each do |arf_report| %>
       <tr>
         <td><%= name_column(arf_report.host) %></td>
+        <td><%= assigned_icon(@policy, arf_report) %></td>
         <td><%= date_time_relative_value(arf_report.reported_at) %></td>
         <td><%= report_arf_column(arf_report.passed, "label-info") %></th>
         <td><%= report_arf_column(arf_report.failed, "label-danger") %></th>

--- a/app/views/policy_dashboard/_policy_status_widget.html.erb
+++ b/app/views/policy_dashboard/_policy_status_widget.html.erb
@@ -1,12 +1,15 @@
 <div id='status-table'>
   <h4 class="header"><%= _('Hosts Breakdown') %></h4>
   <ul>
-    <%= status_link _('Compliant with the policy'), :compliant_hosts, arf_reports_path(:search => "comply_with = \"#{@policy.name}\"") %>
-    <%= status_link _('Not compliant with the policy'), :incompliant_hosts, arf_reports_path(:search => "not_comply_with = \"#{@policy.name}\"") %>
-    <%= status_link _('Inconclusive results'), :inconclusive_hosts, arf_reports_path(:search => " inconclusive_with = \"#{@policy.name}\"") %>
+    <%= status_link _('Compliant with the policy'), :compliant_hosts, hosts_path(:search => "comply_with = \"#{@policy.name}\"") %>
+    <%= status_link _('Not compliant with the policy'), :incompliant_hosts, hosts_path(:search => "not_comply_with = \"#{@policy.name}\"") %>
+    <%= status_link _('Inconclusive results'), :inconclusive_hosts, hosts_path(:search => " inconclusive_with = \"#{@policy.name}\"") %>
     <%= status_link _('Never audited'), :report_missing, hosts_path(:search => "compliance_report_missing_for = \"#{@policy.name}\"") %>
     <h4 class="total">
-      <%= link_to(_("Total hosts: %s") % @report[:assigned_hosts], hosts_path(:search => "compliance_policy = \"#{@policy.name}\"")) %>
+      <%= link_to(_("Total hosts with policy: %s") % @report[:assigned_hosts], hosts_path(:search => "compliance_policy = \"#{@policy.name}\"")) %>
+    </h4>
+    <h4>
+      <%= unassigned_hosts_link %>
     </h4>
   </ul>
 </div>

--- a/test/test_plugin_helper.rb
+++ b/test/test_plugin_helper.rb
@@ -54,7 +54,12 @@ module ScapTestCommon
 
   def create_report_with_rules(host, rule_names, rule_results)
     raise "rule_names and rule_results should have the same length!" if rule_names.size != rule_results.size
-    report = FactoryBot.create(:arf_report, :host_id => host.id)
+    metrics = {
+      'passed' => rule_results.select { |result| result == 'pass' }.count,
+      'failed' => rule_results.select { |result| result == 'fail' }.count,
+      'othered' => rule_results.reject { |result| result == 'fail' || result == 'pass' }.count
+    }
+    report = FactoryBot.create(:arf_report, :host_id => host.id, :metrics => metrics, :status => metrics)
     rule_names.each_with_index do |item, index|
       source = FactoryBot.create(:compliance_source, :value => rule_names[index])
       log = FactoryBot.create(:compliance_log, :source => source, :report => report, :result => rule_results[index])


### PR DESCRIPTION
Policy dashboard now takes into account that there might be hosts with reports where policy is no longer assigned. It shows proper counts in host breakdown and it is easy to find out which hosts are unassigned.

All links in host breakdown widget now point to relevant hosts - previsously, some of them were for reports and others for hosts.