### PR TITLE
Fixes #26693 - Switch Result and Severity in Report

### DIFF
--- a/app/views/arf_reports/_output.html.erb
+++ b/app/views/arf_reports/_output.html.erb
@@ -1,22 +1,22 @@
 <table id='report_log' class="<%= table_css_classes %>">
   <thead>
     <tr>
-      <th><%= _("Severity") %></th>
+      <th><%= _("Result") %></th>
       <th><%= _("Message") %></th>
       <th class="col-md-4"><%= _("Resource") %></th>
-      <th class="col-md-1"><%= _("Result") %></th>
+      <th class="col-md-1"><%= _("Severity") %></th>
       <th class="col-md-1"><%= _("Actions") %></th>
     </tr>
   </thead>
   <tbody>
     <% logs.each do |log| %>
       <tr>
-        <td><span <%= severity_tag log.message.severity %>><%= h log.message.severity %></span></td>
+        <td><span <%= result_tag log.result %>><%= h log.result %></span></td>
         <td>
           <%= render :partial => 'detailed_message', :locals => { :message => log.message } %>
         </td>
         <td><%= log.source %></td>
-        <td><span <%= result_tag log.result %>><%= h log.result %></span></td>
+        <td><span <%= severity_tag log.message.severity %>><%= h log.message.severity %></span></td>
         <td><%= host_search_by_rule_result_buttons(log.source) %></td>
       </tr>
     <% end %>


### PR DESCRIPTION
Currently the pass/fail for each rule in the report is in the fourth column and the severity is in the left. In our lab, this confused many people who saw the severity red boxes and thought the rule was still failing. The first column showing the result column should clear up this confusion. This commit switches those columns.

This is what it looks like:

![hi](http://www.clipular.com/c/6383314928402432.png?k=9A1__JYE8frPv7JUVA58Rz_re8k)