### PR TITLE
Fixes #26001 - Search for Arf reports by partial policy name

### DIFF
--- a/app/models/concerns/foreman_openscap/compliance_status_scoped_search.rb
+++ b/app/models/concerns/foreman_openscap/compliance_status_scoped_search.rb
@@ -5,13 +5,7 @@ module ForemanOpenscap
     module ClassMethods
       def policy_search(search_alias)
         scoped_search :relation => :policy, :on => :name, :complete_value => true, :rename => search_alias,
-              :only_explicit => true, :ext_method => :search_by_policy_name
-      end
-
-      def search_by_policy_name(_key, _operator, policy_name)
-        scope = PolicyArfReport.of_policy(Policy.find_by(:name => policy_name))
-                               .select(PolicyArfReport.arel_table[:arf_report_id]).to_sql
-        query_conditions scope
+              :only_explicit => true
       end
 
       def search_by_comply_with(_key, _operator, policy_name)


### PR DESCRIPTION
Eliminating the method `search_by_policy_name` here, was with the intent that ARF reports can still be searched based on the generic `scoped_search`. With this PR, compliance_policy and policy attributes can be searched with partial policy names.
If this is not the ideal way, I can still mark it as WIP. :-)