### PR TITLE
Fixes #26778 - Compliance report default action wrong

### DIFF
--- a/app/views/arf_reports/_list.html.erb
+++ b/app/views/arf_reports/_list.html.erb
@@ -31,9 +31,10 @@
       <td><%= report_arf_column(arf_report.failed, "label-danger") %></th>
       <td><%= report_arf_column(arf_report.othered, "label-warning") %></th>
       <td>
-        <%= action_buttons(display_delete_if_authorized(hash_for_arf_report_path(:id => arf_report.id),
-                                                        :confirm => _("Delete compliance report for %s?") % arf_report.host),
-                           display_link_if_authorized(_("Full Report"), hash_for_show_html_arf_report_path(:id => arf_report.id)))
+        <%= action_buttons(display_link_if_authorized(_("Full Report"), hash_for_show_html_arf_report_path(:id => arf_report.id
+                          )),
+                           display_delete_if_authorized(hash_for_arf_report_path(:id => arf_report.id),
+                                                        :confirm => _("Delete compliance report for %s?") % arf_report.host))
         %>
       </td>
     </tr>


### PR DESCRIPTION
This PR fixes the default action on Compliance Reports page as Full reports and not Delete.