### PR TITLE
Fixes #27232 - Do not override when lookup_keys missing

### DIFF
--- a/app/models/concerns/foreman_openscap/openscap_proxy_core_extensions.rb
+++ b/app/models/concerns/foreman_openscap/openscap_proxy_core_extensions.rb
@@ -23,6 +23,7 @@ module ForemanOpenscap
       lookup_keys = client_item.public_send(config.override_method_name)
       server_key = lookup_keys.find { |param| param.key == config.server_param }
       port_key = lookup_keys.find { |param| param.key == config.port_param }
+      return if server_key.nil? || port_key.nil?
       pairs = scap_client_lookup_values_for([server_key, port_key], model_match)
       if openscap_proxy_id
         mapping = { config.server_param => openscap_proxy.hostname, config.port_param => openscap_proxy.port }


### PR DESCRIPTION
Important reproducer step is not to have ansible variables for foreman_scap_client role imported, or at least delete the `port` and\or `server`.