### PR TITLE
Fixes #27332 - Speed up the Arf reports loading for host

### DIFF
--- a/app/models/concerns/foreman_openscap/host_extensions.rb
+++ b/app/models/concerns/foreman_openscap/host_extensions.rb
@@ -121,13 +121,11 @@ module ForemanOpenscap
     end
 
     def reports_for_policy(policy, limit = nil)
-      if limit
-        ForemanOpenscap::ArfReport.joins(:policy_arf_report)
-                                  .merge(ForemanOpenscap::PolicyArfReport.of_policy(policy.id)).where(:host_id => id).limit limit
-      else
-        ForemanOpenscap::ArfReport.joins(:policy_arf_report)
-                                  .merge(ForemanOpenscap::PolicyArfReport.of_policy(policy.id)).where(:host_id => id)
-      end
+      report_scope = ForemanOpenscap::ArfReport.unscoped.joins(:policy_arf_report)
+                                               .merge(ForemanOpenscap::PolicyArfReport.of_policy(policy.id)).where(:host_id => id)
+                                               .order("#{ForemanOpenscap::ArfReport.table_name}.created_at DESC")
+      report_scope = report_scope.limit(limit) if limit
+      report_scope
     end
 
     def compliance_status(options = {})

--- a/test/unit/openscap_host_test.rb
+++ b/test/unit/openscap_host_test.rb
@@ -44,10 +44,22 @@ class OpenscapHostTest < ActiveSupport::TestCase
     end
 
     test "reports for policy should return expected reports" do
+      @report_2.created_at += 10.minutes
+      @report_2.save!
       reports = @host.reports_for_policy(@policy)
       assert_equal 2, reports.count
       assert reports.include?(@report_1)
       assert reports.include?(@report_2)
+      # Ensure the last report list first
+      assert_equal @report_2, reports.first
+    end
+
+    test "last report for policy should return the latest report only" do
+      @report_2.created_at += 10.minutes
+      @report_2.save!
+      reports = @host.last_report_for_policy(@policy)
+      assert_equal 1, reports.count
+      assert_equal @report_2, reports.first
     end
 
     test 'scap_status_changed should detect status change' do


### PR DESCRIPTION
Having many reports will dramatically slow down the query to retrieve
reports for a host when Organization.current is set. This triggers the
default scope to filter the reports by Organization. If there are millions
of reports to be filtered, Foreman will spend extremely long time to
construct the report ids to be filtered and also slow down the db query.

This causes the "All Hosts" page to load very slow as Foreman needs to
retrieve the status for all the hosts.

This commit fixed the issue by preventing Foreman to run the default scope.

For more info, you can read the bugzilla or the issue.