### PR TITLE
WIP: Fix "SCAP Content" menu entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Make sure that
 
 1. Log-in to Web Interface
 2. Create new SCAP Content
-  1. Go to *Hosts -> Compliance -> SCAP contents* page
+  1. Go to *Hosts -> Compliance -> SCAP Content* page
   2. Upload DataSteam file
 3. Create new Policy
   1. Go to Hosts -> Compliance -> Policies page

--- a/lib/foreman_openscap/engine.rb
+++ b/lib/foreman_openscap/engine.rb
@@ -139,7 +139,7 @@ module ForemanOpenscap
         menu :top_menu, :compliance_policies, :caption => N_('Policies'),
                                               :url_hash => { :controller => :policies, :action => :index },
                                               :parent => :hosts_menu
-        menu :top_menu, :compliance_contents, :caption => N_('SCAP contents'),
+        menu :top_menu, :compliance_contents, :caption => N_('SCAP Content'),
                                               :url_hash => { :controller => :scap_contents, :action => :index },
                                               :parent => :hosts_menu
         menu :top_menu, :compliance_reports, :caption => N_('Reports'),


### PR DESCRIPTION
* Converts the "SCAP Content" menu entry to title case.
* Converts the uncountable noun "Content" to singular.

Relates to: https://projects.theforeman.org/issues/25223