### PR TITLE
Fixes #28481 - Make scap proxy port an int in enc

### DIFF
--- a/app/models/concerns/foreman_openscap/smart_proxy_extensions.rb
+++ b/app/models/concerns/foreman_openscap/smart_proxy_extensions.rb
@@ -11,7 +11,7 @@ module ForemanOpenscap
     end
 
     def port
-      url.match(PORT_MATCH)[1]
+      url.match(PORT_MATCH)[1].to_i
     end
 
     private

--- a/app/services/foreman_openscap/lookup_key_overrider.rb
+++ b/app/services/foreman_openscap/lookup_key_overrider.rb
@@ -71,16 +71,17 @@ module ForemanOpenscap
     end
 
     def override_port_param(param, config)
-      override_param config.port_param, param, config
+      override_param config.port_param, param, config, 'integer'
     end
 
     def override_server_param(param, config)
       override_param config.server_param, param, config
     end
 
-    def override_param(param_name, param, config)
+    def override_param(param_name, param, config, key_type = nil)
       param.override = true
       param.hidden_value = false
+      param.key_type = key_type if key_type
 
       yield param if block_given?
 

--- a/db/migrate/20200117135424_migrate_port_overrides_to_int.rb
+++ b/db/migrate/20200117135424_migrate_port_overrides_to_int.rb
@@ -1,0 +1,24 @@
+class MigratePortOverridesToInt < ActiveRecord::Migration[5.2]
+  def up
+    transform_lookup_values :to_i
+  end
+
+  def down
+    transform_lookup_values :to_s
+  end
+
+  private
+
+  def transform_lookup_values(method)
+    puppet_class = Puppetclass.find_by :name => 'foreman_scap_client'
+    return unless puppet_class
+    port_key = puppet_class.class_params.find_by :key => 'port'
+    return unless port_key
+    port_key.lookup_values.in_batches do |batch|
+      batch.each do |lookup_value|
+        lookup_value.value = lookup_value.value.send(method)
+        lookup_value.save
+      end
+    end
+  end
+end


### PR DESCRIPTION
Needed for newly added type checks in puppet-foreman_scap_client that enforce port to be an integer instead of a string.

These changes handle new installations, I'll need to create a rake task for existing ones, therefore wip.