### PR TITLE
Fixes #30557 - Change port ansible variable to int

### DIFF
--- a/db/migrate/20200803065041_migrate_port_overrides_for_ansible.rb
+++ b/db/migrate/20200803065041_migrate_port_overrides_for_ansible.rb
@@ -1,0 +1,34 @@
+class MigratePortOverridesForAnsible < ActiveRecord::Migration[6.0]
+  def up
+    transform_lookup_values :to_i
+  end
+
+  def down
+    transform_lookup_values :to_s
+  end
+
+  private
+
+  def transform_lookup_values(method)
+    return unless defined?(ForemanAnsible)
+    role = AnsibleRole.find_by :name => 'theforeman.foreman_scap_client'
+    return unless role
+    port_key = role.ansible_variables.find_by :key => 'foreman_scap_client_port'
+    return unless port_key
+    if method == :to_i
+      port_key.key_type =  "integer"
+      port_key.default_value = 8080
+    else
+      port_key.key_type == "string"
+      port_key.default_value = ""
+    end
+
+    port_key.save
+    port_key.lookup_values.in_batches do |batch|
+      batch.each do |lookup_value|
+        lookup_value.value = lookup_value.value.send(method)
+        lookup_value.save
+      end
+    end
+  end
+end


### PR DESCRIPTION
We need to change foreman_scap_client_port variable type for existing installations when Ansible role and variables were imported on older versions. 