### PR TITLE
Fixes #31008 - add status_link method to compliance-status

### DIFF
--- a/app/models/foreman_openscap/compliance_status.rb
+++ b/app/models/foreman_openscap/compliance_status.rb
@@ -8,6 +8,10 @@ module ForemanOpenscap
       N_('Compliance')
     end
 
+    def status_link
+      host.arf_reports_path(:search => "host = #{host.name}")
+    end
+
     def self.bit_mask(status)
       "#{ArfReport::BIT_NUM * ArfReport::METRIC.index(status)} & #{ArfReport::MAX}"
     end


### PR DESCRIPTION
Compliance status on hosts/show page should be clickable and lead to the last report for the host.
In order to add this in foreman there is a need to create a status_link method in the compliance status.