### PR TITLE
Fixes #31186 - Removed method name collision with katello

### DIFF
--- a/app/models/concerns/foreman_openscap/hostgroup_extensions.rb
+++ b/app/models/concerns/foreman_openscap/hostgroup_extensions.rb
@@ -22,18 +22,10 @@ module ForemanOpenscap
     end
 
     def inherited_openscap_proxy_id
-      inherited_ancestry_attribute(:openscap_proxy_id)
-    end
-
-    unless defined?(Katello::System)
-      private
-
-      def inherited_ancestry_attribute(attribute)
-        if ancestry.present?
-          self[attribute] || self.class.sort_by_ancestry(ancestors.where("#{attribute} is not NULL")).last.try(attribute)
-        else
-          self.send(attribute)
-        end
+      if ancestry.present?
+        self[:openscap_proxy_id] || self.class.sort_by_ancestry(ancestors.where.not(openscap_proxy_id: nil)).last.try(:openscap_proxy_id)
+      else
+        self.send(:openscap_proxy_id)
       end
     end
   end

--- a/app/models/concerns/foreman_openscap/openscap_proxy_core_extensions.rb
+++ b/app/models/concerns/foreman_openscap/openscap_proxy_core_extensions.rb
@@ -33,10 +33,6 @@ module ForemanOpenscap
       end
     end
 
-    def inherited_openscap_proxy_id
-      inherited_ancestry_attribute(:openscap_proxy_id)
-    end
-
     private
 
     def scap_client_lookup_values_for(lookup_keys, model_match)


### PR DESCRIPTION
Since the `inherited_ancestry_attribute` is used only once, removed it so it won't collide with Katello's private method.

Also removed method duplication from `proxy_core_extensions`, since the method is not relevant for hosts (the original `inherited_ancestry_attribute` is not defined on host) and already added to hostgroup by `hostgroup_extensions`.