### PR TITLE
Fixes #31230 - Do not use digest in messages

### DIFF
--- a/app/models/foreman_openscap/arf_report.rb
+++ b/app/models/foreman_openscap/arf_report.rb
@@ -125,11 +125,9 @@ module ForemanOpenscap
               msg = Log.where(:source_id => src.id).order(:id => :desc).first.message
               update_msg_with_changes(msg, log)
             else
-              digest = Digest::SHA1.hexdigest(log[:title])
-              if (msg = Message.find_by(:digest => digest))
+              if (msg = Message.find_by(:value => log[:title]))
                 msg.attributes = {
                   :value => N_(log[:title]),
-                  :digest => digest,
                   :severity => log[:severity],
                   :description => newline_to_space(log[:description]),
                   :rationale => newline_to_space(log[:rationale]),
@@ -137,7 +135,6 @@ module ForemanOpenscap
                 }
               else
                 msg = Message.new(:value => N_(log[:title]),
-                                  :digest => digest,
                                   :severity => log[:severity],
                                   :description => newline_to_space(log[:description]),
                                   :rationale => newline_to_space(log[:rationale]),
@@ -233,7 +230,6 @@ module ForemanOpenscap
       msg.value = incoming_data['title']
 
       return unless msg.changed?
-      msg.digest = Digest::SHA1.hexdigest(msg.value) if msg.value_changed?
       msg.save
     end
   end

--- a/test/factories/compliance_log_factory.rb
+++ b/test/factories/compliance_log_factory.rb
@@ -9,15 +9,9 @@ FactoryBot.define do
 
   factory :compliance_message, :class => :message do
     sequence(:value) { |n| "message#{n}" }
-    after(:build) do |msg|
-      msg.digest = Digest::SHA1.hexdigest(msg.value)
-    end
   end
 
   factory :compliance_source, :class => :source do
     sequence(:value) { |n| "source#{n}" }
-    after(:build) do |source|
-      source.digest = Digest::SHA1.hexdigest(source.value)
-    end
   end
 end

--- a/test/functional/api/v2/compliance/arf_reports_controller_test.rb
+++ b/test/functional/api/v2/compliance/arf_reports_controller_test.rb
@@ -139,7 +139,7 @@ class Api::V2::Compliance::ArfReportsControllerTest < ActionController::TestCase
                                      :date => dates[1].to_i,
                                      :openscap_proxy_name => @proxy.name),
          :session => set_session_user
-    assert_equal Message.where(:digest => ForemanOpenscap::ArfReport.unscoped.last.logs.first.message.digest).count, 1
+    assert_equal Message.where(:value => ForemanOpenscap::ArfReport.unscoped.last.logs.first.message.value).count, 1
   end
 
   test "should recognize changes in messages" do
@@ -187,12 +187,12 @@ class Api::V2::Compliance::ArfReportsControllerTest < ActionController::TestCase
 
     reports = ForemanOpenscap::ArfReport.unscoped.all
     assert_equal reports.count, 2
-
-    new_msgs = Message.where(:value => "Disable Firefox Configuration File ROT-13 Encoding Changed For Test")
+    msg_value = "Disable Firefox Configuration File ROT-13 Encoding Changed For Test"
+    new_msgs = Message.where(:value => msg_value)
     old_msgs = Message.where(:value => "Disable Firefox Configuration File ROT-13 Encoding")
     assert_equal new_msgs.count, 1
     assert_equal old_msgs.count, 0
-    assert_equal new_msgs.first.digest, Digest::SHA1.hexdigest("Disable Firefox Configuration File ROT-13 Encoding Changed For Test")
+    assert_equal new_msgs.first.value, msg_value
   end
 
   test "should find reports by policy name" do


### PR DESCRIPTION
Digest for report messages was dropped as a part
of #30820, so we should no longer use it.