### PR TITLE
Fixes #31186 - Removed method name collision with katello

### DIFF
--- a/app/models/concerns/foreman_openscap/hostgroup_extensions.rb
+++ b/app/models/concerns/foreman_openscap/hostgroup_extensions.rb
@@ -22,18 +22,10 @@ module ForemanOpenscap
     end
 
     def inherited_openscap_proxy_id
-      inherited_ancestry_attribute(:openscap_proxy_id)
-    end
-
-    unless defined?(Katello::System)
-      private
-
-      def inherited_ancestry_attribute(attribute)
-        if ancestry.present?
-          self[attribute] || self.class.sort_by_ancestry(ancestors.where("#{attribute} is not NULL")).last.try(attribute)
-        else
-          self.send(attribute)
-        end
+      if ancestry.present?
+        self[:openscap_proxy_id] || self.class.sort_by_ancestry(ancestors.where.not(openscap_proxy_id: nil)).last.try(:openscap_proxy_id)
+      else
+        self.send(:openscap_proxy_id)
       end
     end
   end

--- a/app/models/concerns/foreman_openscap/openscap_proxy_core_extensions.rb
+++ b/app/models/concerns/foreman_openscap/openscap_proxy_core_extensions.rb
@@ -33,10 +33,6 @@ module ForemanOpenscap
       end
     end
 
-    def inherited_openscap_proxy_id
-      inherited_ancestry_attribute(:openscap_proxy_id)
-    end
-
     private
 
     def scap_client_lookup_values_for(lookup_keys, model_match)


### PR DESCRIPTION
(cherry picked from commit ba787a0e59ae69f355edaa919d341e6d5a3b2806)