### PR TITLE
Fixes #31381 - Register REX features in to_prepare block

### DIFF
--- a/lib/foreman_openscap/engine.rb
+++ b/lib/foreman_openscap/engine.rb
@@ -180,19 +180,6 @@ module ForemanOpenscap
                         :description => proxy_description,
                         :api_description => N_('ID of OpenSCAP Proxy')
 
-        if ForemanOpenscap.with_remote_execution?
-          options = {
-            :description => N_("Run OpenSCAP scan"),
-            :provided_inputs => "policies"
-          }
-
-          if Gem::Version.new(ForemanRemoteExecution::VERSION) >= Gem::Version.new('1.2.3')
-            options[:host_action_button] = true
-          end
-
-          RemoteExecutionFeature.register(:foreman_openscap_run_scans, N_("Run OpenSCAP scan"), options)
-        end
-
         add_controller_action_scope('Api::V2::HostsController', :index) do |base_scope|
           base_scope.preload(:policies)
         end
@@ -231,6 +218,19 @@ module ForemanOpenscap
       Log.send(:include, ForemanOpenscap::LogExtensions)
       BookmarkControllerValidator.send(:prepend, ForemanOpenscap::BookmarkControllerValidatorExtensions)
       ProxyStatus.status_registry.add(ProxyStatus::OpenscapSpool)
+
+      if ForemanOpenscap.with_remote_execution?
+        options = {
+          :description => N_("Run OpenSCAP scan"),
+          :provided_inputs => "policies"
+        }
+
+        if Gem::Version.new(ForemanRemoteExecution::VERSION) >= Gem::Version.new('1.2.3')
+          options[:host_action_button] = true
+        end
+
+        RemoteExecutionFeature.register(:foreman_openscap_run_scans, N_("Run OpenSCAP scan"), options)
+      end
     end
 
     rake_tasks do


### PR DESCRIPTION
When openscap tried to register REX features, REX was not registered as a plugin
yet and because it was not registered yet, the feature registration got skipped.

This had two causes, features being registered from within a plugin registration
block and foreman_openscap being registered before remote execution as a plugin.
To_prepare block is run after all the plugin-registering initializers so it
addresses both causes.