### PR TITLE
Fixes #27748 - Drop taxonomy_enabled checks

### DIFF
--- a/app/models/foreman_openscap/arf_report.rb
+++ b/app/models/foreman_openscap/arf_report.rb
@@ -156,8 +156,8 @@ module ForemanOpenscap
 
     def assign_locations_organizations
       if host
-        self.location_ids = [host.location_id] if SETTINGS[:locations_enabled]
-        self.organization_ids = [host.organization_id] if SETTINGS[:organizations_enabled]
+        self.location_ids = [host.location_id]
+        self.organization_ids = [host.organization_id]
       end
     end
 

--- a/app/models/foreman_openscap/policy.rb
+++ b/app/models/foreman_openscap/policy.rb
@@ -6,6 +6,8 @@ module ForemanOpenscap
     include Taxonomix
     attr_writer :current_step, :wizard_initiated
 
+    STEPS_LIST = [N_('Deployment Options'), N_('Policy Attributes'), N_('SCAP Content'), N_('Schedule'), N_('Locations'), N_('Organizations'), N_('Hostgroups')]
+
     belongs_to :scap_content
     belongs_to :scap_content_profile
     belongs_to :tailoring_file
@@ -108,10 +110,7 @@ module ForemanOpenscap
     end
 
     def steps
-      base_steps = [N_('Deployment Options'), N_('Policy Attributes'), N_('SCAP Content'), N_('Schedule')]
-      base_steps << N_('Locations') if SETTINGS[:locations_enabled]
-      base_steps << N_('Organizations') if SETTINGS[:organizations_enabled]
-      base_steps << N_('Hostgroups') # always be last.
+      STEPS_LIST
     end
 
     def current_step

--- a/db/seeds.d/75-job_templates.rb
+++ b/db/seeds.d/75-job_templates.rb
@@ -11,8 +11,9 @@ if ForemanOpenscap.with_remote_execution?
         else
           template = JobTemplate.import!(File.read(template), :default => true, :lock => true, :update => sync)
         end
-        template.organizations = organizations if SETTINGS[:organizations_enabled] && template.present?
-        template.locations = locations if SETTINGS[:locations_enabled] && template.present?
+        next unless template.present?
+        template.organizations = organizations
+        template.locations = locations
       end
     end
   end

--- a/lib/foreman_openscap/bulk_upload.rb
+++ b/lib/foreman_openscap/bulk_upload.rb
@@ -49,8 +49,8 @@ module ForemanOpenscap
         next if scap_content.persisted?
         scap_content.scap_file = file
         scap_content.original_filename = filename
-        scap_content.location_ids = Location.all.map(&:id)
-        scap_content.organization_ids = Organization.all.map(&:id)
+        scap_content.location_ids = Location.all.pluck(:id)
+        scap_content.organization_ids = Organization.all.pluck(:id)
 
         if scap_content.save
           @result.results.push(scap_content)


### PR DESCRIPTION
This setting has been removed from core in 1.21, no need to check it
anymore.