### PR TITLE
Fixes #32147 - move ARF Reports from Hosts menu to Monitor

### DIFF
--- a/lib/foreman_openscap/engine.rb
+++ b/lib/foreman_openscap/engine.rb
@@ -142,9 +142,10 @@ module ForemanOpenscap
         menu :top_menu, :compliance_contents, :caption => N_('SCAP contents'),
                                               :url_hash => { :controller => :scap_contents, :action => :index },
                                               :parent => :hosts_menu
-        menu :top_menu, :compliance_reports, :caption => N_('Reports'),
+        menu :top_menu, :compliance_reports, :caption => N_('ARF Reports'),
                                              :url_hash => { :controller => :arf_reports, :action => :index },
-                                             :parent => :hosts_menu
+                                             :parent => :monitor_menu,
+                                             :after => :report_templates
         menu :top_menu, :compliance_files, :caption => N_('Tailoring Files'),
                                            :url_hash => { :controller => :tailoring_files, :action => :index },
                                            :parent => :hosts_menu


### PR DESCRIPTION
As was suggested in the menu rename discussion https://docs.google.com/document/d/1eFbHZjuZC40SYqAn93dOXU0nUf3RnL10Bb8uHIk60w4/edit?usp=sharing
Related to: https://github.com/theforeman/foreman/pull/7809
I'm not sure it should be merged before or after the change