### PR TITLE
Switch to gh actions for tests

### DIFF
--- a/.github/workflows/ruby_tests.yml
+++ b/.github/workflows/ruby_tests.yml
@@ -1,0 +1,67 @@
+name: Ruby Testing
+on:
+  pull_request:
+env:
+  BUNDLE_WITHOUT: journald:development:console:libvirt
+  RAILS_ENV: test
+  DATABASE_URL: postgresql://postgres:@localhost/test
+  DATABASE_CLEANER_ALLOW_REMOTE_DATABASE_URL: true
+jobs:
+  test_ruby:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:12.1
+        ports: ['5432:5432']
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+    strategy:
+      fail-fast: false
+      matrix:
+        foreman-core-branch: [develop]
+        foreman-ansible-branch: [master]
+        foreman-rex-branch: [master]
+        ruby-version: [2.5, 2.6]
+    steps:
+      - name: Install build packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install build-essential libcurl4-openssl-dev zlib1g-dev libpq-dev
+      - uses: actions/checkout@v2
+        with:
+          repository: theforeman/foreman
+          ref: ${{ matrix.foreman-core-branch }}
+      - uses: actions/checkout@v2
+        with:
+          repository: theforeman/foreman_ansible
+          ref: ${{ matrix.foreman-ansible-branch }}
+          path: foreman_ansible
+      - uses: actions/checkout@v2
+        with:
+          repository: theforeman/foreman_remote_execution
+          ref: ${{ matrix.foreman-rex-branch }}
+          path: foreman_remote_execution
+      - uses: actions/checkout@v2
+        with:
+          path: foreman_openscap
+      - name: Setup Bundler
+        run: |
+          echo "gem 'foreman_openscap', path: './foreman_openscap'" > bundler.d/foreman_openscap.local.rb
+          echo "gem 'foreman_ansible', path: './foreman_ansible'" > bundler.d/foreman_ansible.local.rb
+          echo "gem 'foreman_remote_execution', path: './foreman_remote_execution'" > bundler.d/foreman_remote_execution.local.rb
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+          bundler-cache: true
+      - name: Prepare test env
+        run: |
+          bundle install
+          bundle exec rake db:create
+          bundle exec rake db:migrate
+      - name: Run rubocop
+        run: bundle exec foreman_openscap:rubocop
+      - name: Run plugin tests
+        run: |
+          bundle exec rake test:foreman_openscap
+      - name: Run selected core tests
+        run: bundle exec rake test:foreman_openscap_extensions

--- a/lib/tasks/foreman_openscap_tasks.rake
+++ b/lib/tasks/foreman_openscap_tasks.rake
@@ -87,17 +87,22 @@ namespace :test do
     t.libs << ["test", test_dir]
     t.pattern = "#{test_dir}/**/*_test.rb"
     t.verbose = true
+    t.warning = false
   end
 end
 
-Rake::Task[:test].enhance do
-  Rake::Task['test:foreman_openscap'].invoke
-end
-
-load 'tasks/jenkins.rake'
-if Rake::Task.task_defined?(:'jenkins:unit')
-  Rake::Task["jenkins:unit"].enhance do
-    Rake::Task['test:foreman_openscap'].invoke
-    Rake::Task['foreman_openscap:rubocop'].invoke
+namespace :test do
+  desc "Test Core parts extended by ForemanOpenscap"
+  Rake::TestTask.new(:foreman_openscap_extensions) do |t|
+    test_dir = Rails.root.join('test')
+    t.libs << ["test", test_dir]
+    t.test_files = FileList[
+      "#{test_dir}/unit/foreman/access_permissions_test.rb",
+      "#{test_dir}/controllers/api/v2/hosts_controller_test.rb",
+      "#{test_dir}/controllers/api/v2/hostgroups_controller_test.rb",
+      "#{test_dir}/models/hosts/*_test.rb",
+      ]
+    t.verbose = true
+    t.warning = false
   end
 end


### PR DESCRIPTION
We need to test with foreman_ansible
to ensure that logic responsible
for config deployment to client
is tested properly. Our Jenkins currently
does not offer any support for testing
multiple plugins together, so a completely
new job would have to be created in JJB.
Swithching to gh actions is easier
and does not require changes
in a different repo.