### PR TITLE
Fixes #32719 - Add new OVAL policy page

### DIFF
--- a/app/graphql/mutations/oval_policies/create.rb
+++ b/app/graphql/mutations/oval_policies/create.rb
@@ -1,0 +1,33 @@
+module Mutations
+  module OvalPolicies
+    class Create < ::Mutations::BaseMutation
+      description 'Creates a new OVAL Policy'
+      graphql_name 'CreateOvalPolicyMutation'
+
+      resource_class ::ForemanOpenscap::OvalPolicy
+
+      argument :name, String
+      argument :description, String, required: false
+      argument :period, String
+      argument :weekday, String, required: false
+      argument :day_of_month, Integer, required: false
+      argument :cron_line, String, required: false
+      argument :oval_content_id, Integer, required: true
+      argument :hostgroup_ids, [Integer], required: false
+
+      field :oval_policy, Types::OvalPolicy, 'The new OVAL Policy.', null: true
+      field :check_collection, [Types::OvalCheck], 'A collection of checks to detect OVAL policy configuration error', null: false
+
+      def resolve(hostgroup_ids:, **params)
+        policy = ::ForemanOpenscap::OvalPolicy.new params
+        validate_object(policy)
+        authorize!(policy, :create)
+        check_collection = ::ForemanOpenscap::Oval::Configure.new.assign(policy, hostgroup_ids, ::Hostgroup)
+        {
+          :oval_policy => policy,
+          :check_collection => check_collection.checks
+        }
+      end
+    end
+  end
+end

--- a/app/models/concerns/foreman_openscap/oval_facet_hostgroup_extensions.rb
+++ b/app/models/concerns/foreman_openscap/oval_facet_hostgroup_extensions.rb
@@ -11,6 +11,7 @@ module ForemanOpenscap
                     :on => :id,
                     :rename => :oval_policy_id,
                     :complete_value => false,
+                    :only_explicit => true,
                     :ext_method => :find_by_oval_policy_id,
                     :operators => ['= ']
     end

--- a/app/services/foreman_openscap/oval/configure.rb
+++ b/app/services/foreman_openscap/oval/configure.rb
@@ -16,21 +16,26 @@ module ForemanOpenscap
         if model_class == ::Hostgroup
           roles_method = :inherited_and_own_ansible_roles
           ids_setter = :hostgroup_ids=
+          check_id = :hostgroups_without_proxy
         elsif model_class == ::Host::Managed
           roles_method = :all_ansible_roles
           ids_setter = :host_ids=
+          check_id = :hosts_without_proxy
         else
           raise "Unexpected model_class, expected ::Hostgroup or ::Host::Managed, got: #{model_class}"
         end
 
         items_with_proxy, items_without_proxy = openscap_proxy_associated(ids, model_class)
 
+
+        if items_without_proxy.any?
+          return without_proxy_to_check items_without_proxy, check_id
+        end
+
         oval_policy.send(ids_setter, items_with_proxy.pluck(:id))
 
-        check_collection = without_proxy_to_check items_without_proxy
-
         unless oval_policy.save
-          return check_collection.add_check model_to_check(oval_policy)
+          return check_collection.add_check model_to_check(oval_policy, :oval_policy_errors)
         end
 
         check_collection.merge modify_items(items_with_proxy, oval_policy, ansible_role, roles_method)
@@ -47,31 +52,29 @@ module ForemanOpenscap
           role_ids = item.ansible_role_ids + [ansible_role.id]
           item.ansible_role_ids = role_ids unless item.send(roles_method).include? ansible_role
           item.save if item.changed?
-          memo.add_check model_to_check(item)
+          memo.add_check model_to_check(item, item.is_a?(::Hostgroup) ? 'hostgroup' : 'host')
           add_overrides ansible_role.ansible_variables, item, @config
           memo
         end
       end
 
-      def without_proxy_to_check(items)
+      def without_proxy_to_check(items, check_id)
         items.reduce(CheckCollection.new) do |memo, item|
           memo.add_check(
             SetupCheck.new(
               :title => (_("Was %s configured successfully?") % item.class.name),
-              :fail_msg => (_("Assign openscap_proxy to %s before proceeding.") % item.name)
+              :fail_msg => (_("Assign openscap_proxy to %s before proceeding.") % item.name),
+              :id => check_id
             ).fail!
           )
         end
       end
 
-      def model_to_s(model)
-        model.is_a?(::Hostgroup) ? 'hostgroup' : 'host'
-      end
-
-      def model_to_check(model)
+      def model_to_check(model, check_id)
         check = SetupCheck.new(
-          :title => (_("Was %{model_name} %{name} configured successfully?") % { :model_name => model_to_s(model), :name => model.name }),
-          :errors => model.errors.to_h
+          :title => (_("Was %{model_name} %{name} configured successfully?") % { :model_name => model.class.name, :name => model.name }),
+          :errors => model.errors.to_h,
+          :id => check_id
         )
         model.errors.any? ? check.fail! : check.pass!
       end

--- a/app/services/foreman_openscap/oval/setup_check.rb
+++ b/app/services/foreman_openscap/oval/setup_check.rb
@@ -1,7 +1,7 @@
 module ForemanOpenscap
   module Oval
     class SetupCheck
-      attr_reader :result, :id, :errors
+      attr_reader :result, :id, :title, :errors
 
       def initialize(hash)
         @id = hash[:id]

--- a/lib/foreman_openscap/engine.rb
+++ b/lib/foreman_openscap/engine.rb
@@ -227,6 +227,7 @@ module ForemanOpenscap
         register_graphql_mutation_field :delete_oval_policy, ::Mutations::OvalPolicies::Delete
         register_graphql_mutation_field :delete_oval_content, ::Mutations::OvalContents::Delete
         register_graphql_mutation_field :update_oval_policy, ::Mutations::OvalPolicies::Update
+        register_graphql_mutation_field :create_oval_policy, ::Mutations::OvalPolicies::Create
 
         register_facet ForemanOpenscap::Host::OvalFacet, :oval_facet do
           configure_host do

--- a/webpack/components/IndexTable/index.js
+++ b/webpack/components/IndexTable/index.js
@@ -59,7 +59,7 @@ IndexTable.propTypes = {
 };
 
 IndexTable.defaultProps = {
-  toolbarBtns: [],
+  toolbarBtns: null,
 };
 
 export default IndexTable;

--- a/webpack/components/LinkButton.js
+++ b/webpack/components/LinkButton.js
@@ -3,9 +3,19 @@ import { Link } from 'react-router-dom';
 import { Button } from '@patternfly/react-core';
 import PropTypes from 'prop-types';
 
-const LinkButton = ({ path, btnVariant, btnText, isDisabled }) => (
+const LinkButton = ({
+  path,
+  btnVariant,
+  btnText,
+  isDisabled,
+  btnAriaLabel,
+}) => (
   <Link to={path}>
-    <Button variant={btnVariant} isDisabled={isDisabled}>
+    <Button
+      variant={btnVariant}
+      isDisabled={isDisabled}
+      aria-label={btnAriaLabel}
+    >
       {btnText}
     </Button>
   </Link>
@@ -16,11 +26,13 @@ LinkButton.propTypes = {
   btnText: PropTypes.string.isRequired,
   btnVariant: PropTypes.string,
   isDisabled: PropTypes.bool,
+  btnAriaLabel: PropTypes.string,
 };
 
 LinkButton.defaultProps = {
   btnVariant: 'primary',
   isDisabled: false,
+  btnAriaLabel: null,
 };
 
 export default LinkButton;

--- a/webpack/components/withLoading.js
+++ b/webpack/components/withLoading.js
@@ -10,7 +10,6 @@ import {
 import EmptyState from './EmptyState';
 
 const errorStateTitle = __('Error!');
-const emptyStateBody = '';
 
 const pluckData = (data, path) => {
   const split = path.split('.');
@@ -28,6 +27,7 @@ const withLoading = Component => {
     resultPath,
     renameData,
     emptyStateTitle,
+    emptyStateBody,
     permissions,
     primaryButton,
     shouldRefetch,
@@ -87,6 +87,7 @@ const withLoading = Component => {
     resultPath: PropTypes.string.isRequired,
     renameData: PropTypes.func,
     emptyStateTitle: PropTypes.string.isRequired,
+    emptyStateBody: PropTypes.string,
     permissions: PropTypes.array,
     primaryButton: PropTypes.node,
     shouldRefetch: PropTypes.bool,
@@ -97,6 +98,7 @@ const withLoading = Component => {
     permissions: [],
     primaryButton: null,
     shouldRefetch: false,
+    emptyStateBody: '',
   };
 
   return Subcomponent;

--- a/webpack/graphql/mutations/createOvalPolicy.gql
+++ b/webpack/graphql/mutations/createOvalPolicy.gql
@@ -1,0 +1,22 @@
+mutation CreateOvalPolicy($name: String!, $period: String!, $cronLine: String, $ovalContentId: Int!, $hostgroupIds: [Int!]) {
+  createOvalPolicy(input: {name: $name, period: $period, cronLine: $cronLine, ovalContentId: $ovalContentId, hostgroupIds: $hostgroupIds}) {
+    ovalPolicy {
+      name
+      id
+      period
+      cronLine
+      hostgroups {
+        nodes {
+          name
+          id
+        }
+      }
+    }
+    checkCollection {
+      id
+      errors
+      failMsg
+      result
+    }
+  }
+}

--- a/webpack/helpers/formFieldsHelper.js
+++ b/webpack/helpers/formFieldsHelper.js
@@ -1,8 +1,57 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { FormGroup, TextInput } from '@patternfly/react-core';
+import {
+  FormGroup,
+  TextInput,
+  TextArea,
+  FormSelect,
+  FormSelectOption,
+} from '@patternfly/react-core';
 import { ExclamationCircleIcon } from '@patternfly/react-icons';
+
+export const SelectField = props => {
+  const { selectItems, field, form } = props;
+  const fieldProps = wrapFieldProps(field);
+
+  const valid = shouldValidate(form, field.name);
+
+  return (
+    <FormGroup
+      label={props.label}
+      isRequired={props.isRequired}
+      helperTextInvalid={form.errors[field.name]}
+      helperTextInvalidIcon={<ExclamationCircleIcon />}
+      validated={valid}
+    >
+      <FormSelect
+        {...fieldProps}
+        className="without_select2"
+        aria-label={fieldProps.name}
+        validated={valid}
+        isDisabled={form.isSubmitting}
+      >
+        <FormSelectOption key={0} value="" label={props.blankLabel} />
+        {selectItems.map((item, idx) => (
+          <FormSelectOption key={idx + 1} value={item.id} label={item.name} />
+        ))}
+      </FormSelect>
+    </FormGroup>
+  );
+};
+
+SelectField.propTypes = {
+  selectItems: PropTypes.array,
+  label: PropTypes.string.isRequired,
+  isRequired: PropTypes.bool,
+  field: PropTypes.object.isRequired,
+  form: PropTypes.object.isRequired,
+  blankLabel: PropTypes.string.isRequired,
+};
+SelectField.defaultProps = {
+  selectItems: [],
+  isRequired: false,
+};
 
 const wrapFieldProps = fieldProps => {
   const { onChange } = fieldProps;
@@ -61,3 +110,4 @@ const fieldWithHandlers = Component => {
 };
 
 export const TextField = fieldWithHandlers(TextInput);
+export const TextAreaField = fieldWithHandlers(TextArea);

--- a/webpack/helpers/globalIdHelper.js
+++ b/webpack/helpers/globalIdHelper.js
@@ -4,8 +4,10 @@ const idSeparator = '-';
 const versionSeparator = ':';
 const defaultVersion = '01';
 
-export const decodeId = model => {
-  const split = atob(model.id).split(idSeparator);
+export const decodeModelId = model => decodeId(model.id);
+
+export const decodeId = globalId => {
+  const split = atob(globalId).split(idSeparator);
   return parseInt(last(split), 10);
 };
 

--- a/webpack/helpers/pathsHelper.js
+++ b/webpack/helpers/pathsHelper.js
@@ -1,11 +1,12 @@
-import { decodeId } from './globalIdHelper';
+import { decodeModelId } from './globalIdHelper';
 
 const experimental = path => `/experimental${path}`;
 
 const showPath = path => `${path}/:id`;
 const newPath = path => `${path}/new`;
 
-export const modelPath = (basePath, model) => `${basePath}/${decodeId(model)}`;
+export const modelPath = (basePath, model) =>
+  `${basePath}/${decodeModelId(model)}`;
 
 // react-router uses path-to-regexp, should we use it as well in a future?
 // https://github.com/pillarjs/path-to-regexp/tree/v1.7.0#compile-reverse-path-to-regexp
@@ -22,6 +23,7 @@ export const ovalContentsShowPath = showPath(ovalContentsPath);
 export const ovalContentsNewPath = newPath(ovalContentsPath);
 export const ovalPoliciesPath = experimental('/compliance/oval_policies');
 export const ovalPoliciesShowPath = `${showPath(ovalPoliciesPath)}/:tab?`;
+export const ovalPoliciesNewPath = newPath(ovalPoliciesPath);
 export const hostsPath = '/hosts';
-export const newJobPath = '/job_invocations/new';
+export const newJobPath = newPath('/job_invocations');
 export const hostsShowPath = showPath(hostsPath);

--- a/webpack/helpers/toastsHelper.js
+++ b/webpack/helpers/toastsHelper.js
@@ -1,0 +1,3 @@
+import { addToast } from 'foremanReact/redux/actions/toasts';
+
+export const showToast = dispatch => toast => dispatch(addToast(toast));

--- a/webpack/routes/OvalContents/OvalContentsIndex/__tests__/OvalContentsIndex.fixtures.js
+++ b/webpack/routes/OvalContents/OvalContentsIndex/__tests__/OvalContentsIndex.fixtures.js
@@ -56,7 +56,8 @@ const ovalContentNodes = [
   thirdContent(),
   fourthContent(),
 ];
-const ovalContents = {
+
+export const ovalContents = {
   totalCount: ovalContentNodes.length,
   nodes: ovalContentNodes,
 };
@@ -69,6 +70,10 @@ export const mocks = ovalContentMockFactory(
   },
   { currentUser: admin }
 );
+
+export const unpagedMocks = ovalContentMockFactory({}, ovalContents, {
+  currentUser: admin,
+});
 
 export const paginatedMocks = ovalContentMockFactory(
   { first: 10, last: 5 },

--- a/webpack/routes/OvalPolicies/OvalPoliciesIndex/OvalPoliciesTable.js
+++ b/webpack/routes/OvalPolicies/OvalPoliciesIndex/OvalPoliciesTable.js
@@ -1,5 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { Button } from '@patternfly/react-core';
+
 import { translate as __ } from 'foremanReact/common/I18n';
 
 import IndexTable from '../../../components/IndexTable';
@@ -7,7 +9,11 @@ import withLoading from '../../../components/withLoading';
 import withDeleteModal from '../../../components/withDeleteModal';
 
 import { linkCell } from '../../../helpers/tableHelper';
-import { ovalPoliciesPath, modelPath } from '../../../helpers/pathsHelper';
+import {
+  ovalPoliciesPath,
+  modelPath,
+  ovalPoliciesNewPath,
+} from '../../../helpers/pathsHelper';
 
 const OvalPoliciesTable = props => {
   const columns = [{ title: __('Name') }, { title: __('OVAL Content') }];
@@ -33,6 +39,16 @@ const OvalPoliciesTable = props => {
     return actions;
   };
 
+  const createBtn = (
+    <Button
+      onClick={() => props.history.push(ovalPoliciesNewPath)}
+      variant="primary"
+      aria-label="create_oval_policy"
+    >
+      {__('Create OVAL Policy')}
+    </Button>
+  );
+
   return (
     <IndexTable
       columns={columns}
@@ -42,6 +58,7 @@ const OvalPoliciesTable = props => {
       totalCount={props.totalCount}
       history={props.history}
       ariaTableLabel={__('OVAL Policies Table')}
+      toolbarBtns={createBtn}
     />
   );
 };

--- a/webpack/routes/OvalPolicies/OvalPoliciesNew/HostgroupSelect.js
+++ b/webpack/routes/OvalPolicies/OvalPoliciesNew/HostgroupSelect.js
@@ -1,0 +1,135 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import { useLazyQuery } from '@apollo/client';
+import { translate as __, sprintf } from 'foremanReact/common/I18n';
+import {
+  Select,
+  SelectOption,
+  SelectVariant,
+  FormGroup,
+} from '@patternfly/react-core';
+import { ExclamationCircleIcon } from '@patternfly/react-icons';
+import hostgroupsQuery from '../../../graphql/queries/hostgroups.gql';
+
+const HostgroupSelect = ({
+  selected,
+  setSelected,
+  hgsError,
+  showError,
+  setShowError,
+}) => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const [typingTimeout, setTypingTimeout] = useState(null);
+
+  const [fetchHostgroups, { loading, data, error }] = useLazyQuery(
+    hostgroupsQuery
+  );
+  const results = data?.hostgroups?.nodes ? data.hostgroups.nodes : [];
+
+  const onSelect = (event, selection) => {
+    if (selected.find(item => item.name === selection)) {
+      setSelected(selected.filter(item => item.name !== selection));
+    } else {
+      const hg = results.find(item => item.name === selection);
+      setSelected([...selected, hg]);
+    }
+  };
+
+  const onClear = () => {
+    if (showError) {
+      setShowError(false);
+    }
+    setSelected([]);
+  };
+
+  const onInputChange = value => {
+    if (showError) {
+      setShowError(false);
+    }
+    if (typingTimeout) {
+      clearTimeout(typingTimeout);
+    }
+    const variables = { search: `name ~ ${value}` };
+    setTypingTimeout(setTimeout(() => fetchHostgroups({ variables }), 500));
+  };
+
+  const shouldValidate = (err, shouldShowError) => {
+    if (shouldShowError) {
+      return err ? 'error' : 'success';
+    }
+    return 'noval';
+  };
+
+  const prepareOptions = fetchedResults => {
+    if (loading) {
+      return [
+        <SelectOption isDisabled key={0}>
+          {__('Loading...')}
+        </SelectOption>,
+      ];
+    }
+
+    if (error) {
+      return [
+        <SelectOption isDisabled key={0}>
+          {sprintf('Failed to fetch hostgroups, cause: %s', error.message)}
+        </SelectOption>,
+      ];
+    }
+
+    if (fetchedResults.length > 20) {
+      return [
+        <SelectOption isDisabled key={0}>
+          {sprintf(
+            'You have %s hostgroups to display. Please refine your search.',
+            fetchedResults.length
+          )}
+        </SelectOption>,
+      ];
+    }
+
+    return fetchedResults.map((hg, idx) => (
+      <SelectOption key={hg.id} value={hg.name} />
+    ));
+  };
+
+  return (
+    <FormGroup
+      label={__('Hostgroups')}
+      helperTextInvalidIcon={<ExclamationCircleIcon />}
+      helperTextInvalid={showError && hgsError}
+      validated={shouldValidate(hgsError, showError)}
+    >
+      <Select
+        variant={SelectVariant.typeaheadMulti}
+        typeAheadAriaLabel="Select a hostgroup"
+        placeholderText="Type a hostroup name..."
+        onToggle={() => setIsOpen(!isOpen)}
+        onSelect={onSelect}
+        onClear={onClear}
+        selections={selected.map(item => item.name)}
+        isOpen={isOpen}
+        onTypeaheadInputChanged={onInputChange}
+        validated={shouldValidate(hgsError, showError)}
+      >
+        {prepareOptions(results)}
+      </Select>
+    </FormGroup>
+  );
+};
+
+HostgroupSelect.propTypes = {
+  selected: PropTypes.array,
+  setSelected: PropTypes.func.isRequired,
+  hgsError: PropTypes.string,
+  showError: PropTypes.bool.isRequired,
+  setShowError: PropTypes.func.isRequired,
+};
+
+HostgroupSelect.defaultProps = {
+  selected: [],
+  hgsError: '',
+};
+
+export default HostgroupSelect;

--- a/webpack/routes/OvalPolicies/OvalPoliciesNew/NewOvalPolicyForm.js
+++ b/webpack/routes/OvalPolicies/OvalPoliciesNew/NewOvalPolicyForm.js
@@ -1,0 +1,119 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import { Formik, Field as FormikField } from 'formik';
+import { useMutation } from '@apollo/client';
+import { translate as __ } from 'foremanReact/common/I18n';
+import { Button, Form as PfForm, ActionGroup } from '@patternfly/react-core';
+
+import createOvalPolicy from '../../../graphql/mutations/createOvalPolicy.gql';
+
+import {
+  TextField,
+  TextAreaField,
+  SelectField,
+} from '../../../helpers/formFieldsHelper';
+import HostgroupSelect from './HostgroupSelect';
+import withLoading from '../../../components/withLoading';
+
+import { ovalPoliciesPath } from '../../../helpers/pathsHelper';
+import LinkButton from '../../../components/LinkButton';
+
+import {
+  createValidationSchema,
+  onSubmit,
+  initialValues,
+} from './NewOvalPolicyFormHelpers';
+
+const NewOvalPolicyForm = ({ history, showToast, ovalContents }) => {
+  const [callMutation] = useMutation(createOvalPolicy);
+
+  const [assignedHgs, setAssignedHgs] = useState([]);
+  const [hgsShowError, setHgsShowError] = useState(false);
+  const [hgsError, setHgsError] = useState('');
+
+  const onHgsError = error => {
+    setHgsShowError(true);
+    setHgsError(error);
+  };
+
+  return (
+    <Formik
+      onSubmit={onSubmit(
+        history,
+        showToast,
+        callMutation,
+        assignedHgs,
+        onHgsError
+      )}
+      initialValues={initialValues}
+      validationSchema={createValidationSchema()}
+    >
+      {formProps => (
+        <PfForm>
+          <FormikField
+            name="name"
+            component={TextField}
+            label={__('Name')}
+            isRequired
+          />
+          <FormikField
+            name="description"
+            component={TextAreaField}
+            label={__('Description')}
+          />
+          <FormikField
+            name="cronLine"
+            component={TextField}
+            label={__('Schedule')}
+            isRequired
+          />
+          <FormikField
+            name="ovalContentId"
+            component={SelectField}
+            selectItems={ovalContents}
+            label={__('OVAL Content')}
+            isRequired
+            blankLabel={__('Choose OVAL Content')}
+          />
+          <HostgroupSelect
+            selected={assignedHgs}
+            setSelected={setAssignedHgs}
+            showError={hgsShowError}
+            setShowError={setHgsShowError}
+            hgsError={hgsError}
+            isDisabled={formProps.isSubmitting}
+          />
+          <ActionGroup>
+            <Button
+              variant="primary"
+              onClick={formProps.handleSubmit}
+              isDisabled={
+                !formProps.isValid ||
+                formProps.isSubmitting ||
+                (hgsShowError && hgsError)
+              }
+              aria-label="submit"
+            >
+              {__('Submit')}
+            </Button>
+            <LinkButton
+              path={ovalPoliciesPath}
+              btnVariant="link"
+              btnText={__('Cancel')}
+              btnAriaLabel="cancel"
+              isDisabled={formProps.isSubmitting}
+            />
+          </ActionGroup>
+        </PfForm>
+      )}
+    </Formik>
+  );
+};
+
+NewOvalPolicyForm.propTypes = {
+  history: PropTypes.object.isRequired,
+  showToast: PropTypes.func.isRequired,
+  ovalContents: PropTypes.array.isRequired,
+};
+
+export default withLoading(NewOvalPolicyForm);

--- a/webpack/routes/OvalPolicies/OvalPoliciesNew/NewOvalPolicyFormHelpers.js
+++ b/webpack/routes/OvalPolicies/OvalPoliciesNew/NewOvalPolicyFormHelpers.js
@@ -1,0 +1,107 @@
+import * as Yup from 'yup';
+import { translate as __ } from 'foremanReact/common/I18n';
+
+import { ovalPoliciesPath } from '../../../helpers/pathsHelper';
+import { decodeId, decodeModelId } from '../../../helpers/globalIdHelper';
+
+export const createValidationSchema = () => {
+  const cantBeBlank = __("can't be blank");
+
+  return Yup.object().shape({
+    name: Yup.string().required(cantBeBlank),
+    ovalContentId: Yup.string().required(cantBeBlank),
+    cronLine: Yup.string().test(
+      'is-cron',
+      __('is not a valid cronline'),
+      value => value && value.trim().split(' ').length === 5
+    ),
+  });
+};
+
+const partitionById = (array, name) => {
+  const res = array.reduce(
+    (memo, item) => {
+      if (item.id === name) {
+        memo.left.push(item);
+      } else {
+        memo.right.push(item);
+      }
+      return memo;
+    },
+    { left: [], right: [] }
+  );
+  return [res.left, res.right];
+};
+
+const checksToMessage = checks =>
+  checks.reduce((memo, check) => [...memo, check.failMsg], []).join(' ');
+
+export const onSubmit = (
+  history,
+  showToast,
+  callMutation,
+  assignedHgs,
+  setHgsError
+) => (values, actions) => {
+  const onCompleted = response => {
+    const failedChecks = response.data.createOvalPolicy.checkCollection.filter(
+      check => check.result === 'fail'
+    );
+    if (failedChecks.length === 0) {
+      history.push(ovalPoliciesPath);
+      showToast({
+        type: 'success',
+        message: 'OVAL Policy succesfully created.',
+      });
+    } else {
+      actions.setSubmitting(false);
+
+      const [validationChecks, withoutValidationChecks] = partitionById(
+        failedChecks,
+        'oval_policy_errors'
+      );
+
+      const [hgChecks, remainingChecks] = partitionById(
+        withoutValidationChecks,
+        'hostgroups_without_proxy'
+      );
+      if (validationChecks.length === 1) {
+        actions.setErrors(validationChecks[0].errors);
+      }
+      if (hgChecks.length > 0) {
+        setHgsError(checksToMessage(hgChecks));
+      }
+      if (remainingChecks.length > 0) {
+        showToast({
+          type: 'error',
+          message: checksToMessage(remainingChecks),
+        });
+      }
+    }
+  };
+
+  const onError = response => {
+    showToast({
+      type: 'error',
+      message: `Failed to create OVAL Policy: ${response.error}`,
+    });
+    actions.setSubmitting(false);
+  };
+
+  const hostgroupIds = assignedHgs.map(decodeModelId);
+  const variables = {
+    ...values,
+    ovalContentId: decodeId(values.ovalContentId),
+    period: 'custom',
+    hostgroupIds,
+  };
+  // eslint-disable-next-line promise/prefer-await-to-then
+  callMutation({ variables }).then(onCompleted, onError);
+};
+
+export const initialValues = {
+  name: '',
+  description: '',
+  ovalContentId: '',
+  cronLine: '',
+};

--- a/webpack/routes/OvalPolicies/OvalPoliciesNew/OvalPoliciesNew.js
+++ b/webpack/routes/OvalPolicies/OvalPoliciesNew/OvalPoliciesNew.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import { useQuery } from '@apollo/client';
+import { translate as __ } from 'foremanReact/common/I18n';
+import IndexLayout from '../../../components/IndexLayout';
+
+import ovalContentsQuery from '../../../graphql/queries/ovalContents.gql';
+import NewOvalPolicyForm from './NewOvalPolicyForm';
+
+const OvalPoliciesNew = props => {
+  const useFetchFn = () => useQuery(ovalContentsQuery);
+
+  const renameData = data => ({
+    ovalContents: data.ovalContents.nodes,
+  });
+
+  return (
+    <IndexLayout pageTitle={__('Create OVAL Policy')}>
+      <NewOvalPolicyForm
+        fetchFn={useFetchFn}
+        renameData={renameData}
+        resultPath="ovalContents.nodes"
+        emptyStateTitle={__('No OVAL Content found')}
+        emptyStateBody={__(
+          'OVAL Content is required to create OVAL Policy. Please create one before proceeding.'
+        )}
+        {...props}
+      />
+    </IndexLayout>
+  );
+};
+
+export default OvalPoliciesNew;

--- a/webpack/routes/OvalPolicies/OvalPoliciesNew/__tests__/OvalPoliciesNew.fixtures.js
+++ b/webpack/routes/OvalPolicies/OvalPoliciesNew/__tests__/OvalPoliciesNew.fixtures.js
@@ -1,0 +1,147 @@
+import createOvalPolicy from '../../../../graphql/mutations/createOvalPolicy.gql';
+import hostgroupsQuery from '../../../../graphql/queries/hostgroups.gql';
+
+import { mockFactory, admin } from '../../../../testHelper';
+import { decodeId } from '../../../../helpers/globalIdHelper';
+import { ovalContents } from '../../../OvalContents/OvalContentsIndex/__tests__/OvalContentsIndex.fixtures';
+
+export const newPolicyName = 'test policy';
+export const newPolicyDescription = 'random description';
+export const newPolicyCronline = '5 5 5 5 5';
+export const newPolicyContentName = ovalContents.nodes[1].name;
+export const newPolicyContentId = ovalContents.nodes[1].id;
+const hostgroupId = 3;
+
+const createPolicyMockFactory = mockFactory(
+  'createOvalPolicy',
+  createOvalPolicy
+);
+const hostgroupsMockFactory = mockFactory('hostgroups', hostgroupsQuery);
+
+const foremanAnsiblePresent = {
+  id: 'foreman_ansible_present',
+  errors: null,
+  failMsg: null,
+  result: 'pass',
+};
+const rolePresent = {
+  id: 'foreman_scap_client_role_present',
+  errors: null,
+  failMsg: null,
+  result: 'pass',
+};
+const roleVarsPresent = {
+  id: 'foreman_scap_client_vars_present',
+  errors: null,
+  failMsg: null,
+  result: 'pass',
+};
+const serverVarOverriden = {
+  id: 'foreman_scap_client_server_overriden',
+  errors: null,
+  failMsg: null,
+  result: 'pass',
+};
+const portVarOverriden = {
+  id: 'foreman_scap_client_port_overriden',
+  errors: null,
+  failMsg: null,
+  result: 'pass',
+};
+const policiesVarOverriden = {
+  id: 'foreman_scap_client_policies_overriden',
+  errors: null,
+  failMsg: null,
+  result: 'pass',
+};
+const policyErrors = {
+  id: 'oval_policy_errors',
+  errors: { name: 'has already been taken' },
+  failMsg: null,
+  result: 'fail',
+};
+export const hgWithoutProxy = {
+  id: 'hostgroups_without_proxy',
+  errors: null,
+  failMsg: 'Assign openscap_proxy to first hostgroup before proceeding.',
+  result: 'fail',
+};
+export const roleAbsent = {
+  id: 'foreman_scap_client_role_present',
+  errors: null,
+  failMsg:
+    'theforeman.foreman_scap_client Ansible Role not found, please import it before running this action again.',
+  result: 'fail',
+};
+
+const varChecks = [
+  roleVarsPresent,
+  serverVarOverriden,
+  portVarOverriden,
+  policiesVarOverriden,
+];
+const checkCollectionPass = [foremanAnsiblePresent, rolePresent, ...varChecks];
+const checkCollectionPreconditionFail = [
+  foremanAnsiblePresent,
+  roleAbsent,
+  ...varChecks.map(check => ({ ...check, result: 'skip' })),
+];
+const ovalPolicy = {
+  name: newPolicyName,
+  id: 'MDE6Rm9yZW1hbk9wZW5zY2FwOjpPdmFsUG9saWN5LTcw',
+  period: 'custom',
+  cronLine: newPolicyCronline,
+  hostgroups: {
+    nodes: [],
+  },
+};
+
+const policyCreateSuccess = {
+  checkCollection: checkCollectionPass,
+  ovalPolicy,
+};
+
+const baseVariables = {
+  name: newPolicyName,
+  description: '',
+  ovalContentId: decodeId(newPolicyContentId),
+  cronLine: newPolicyCronline,
+  hostgroupIds: [],
+  period: 'custom',
+};
+
+export const firstHg = {
+  id: 'MDE6SG9zdGdyb3VwLTM=',
+  name: 'first hostgroup',
+};
+
+const successVariables = {
+  ...baseVariables,
+  description: newPolicyDescription,
+};
+
+export const policySuccessMock = createPolicyMockFactory(
+  successVariables,
+  policyCreateSuccess
+);
+
+export const policyValidationMock = createPolicyMockFactory(baseVariables, {
+  checkCollection: [...checkCollectionPass, policyErrors],
+  ovalPolicy,
+});
+
+export const policyPreconditionMock = createPolicyMockFactory(baseVariables, {
+  checkCollection: checkCollectionPreconditionFail,
+  ovalPolicy,
+});
+
+export const policyInvalidHgMock = createPolicyMockFactory(
+  { ...baseVariables, hostgroupIds: [hostgroupId] },
+  { checkCollection: [...checkCollectionPass, hgWithoutProxy], ovalPolicy }
+);
+
+export const hostgroupsMock = hostgroupsMockFactory(
+  { search: `name ~ first` },
+  { totalCount: 2, nodes: [firstHg] },
+  { currentUser: admin }
+);

--- a/webpack/routes/OvalPolicies/OvalPoliciesNew/__tests__/OvalPoliciesNew.test.js
+++ b/webpack/routes/OvalPolicies/OvalPoliciesNew/__tests__/OvalPoliciesNew.test.js
@@ -1,0 +1,172 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import userEvent from '@testing-library/user-event';
+
+import OvalPoliciesNew from '../';
+import { ovalPoliciesPath } from '../../../../helpers/pathsHelper';
+
+import { unpagedMocks as ovalContentMocks } from '../../../OvalContents/OvalContentsIndex/__tests__/OvalContentsIndex.fixtures';
+
+import {
+  withMockedProvider,
+  wait,
+  withRouter,
+  withRedux,
+} from '../../../../testHelper';
+
+import {
+  newPolicyName,
+  newPolicyDescription,
+  newPolicyCronline,
+  newPolicyContentName,
+  policySuccessMock,
+  policyValidationMock,
+  policyPreconditionMock,
+  policyInvalidHgMock,
+  hostgroupsMock,
+  firstHg,
+  roleAbsent as roleAbsentCheck,
+  hgWithoutProxy as withoutProxyCheck,
+} from './OvalPoliciesNew.fixtures';
+
+import * as toasts from '../../../../helpers/toastsHelper';
+
+const TestComponent = withRouter(
+  withRedux(withMockedProvider(OvalPoliciesNew))
+);
+
+describe('OvalPoliciesNew', () => {
+  it('should create new OVAL policy', async () => {
+    const showToast = jest.fn();
+    jest.spyOn(toasts, 'showToast').mockImplementation(() => showToast);
+    const pushMock = jest.fn();
+
+    render(
+      <TestComponent
+        mocks={ovalContentMocks.concat(policySuccessMock)}
+        history={{
+          push: pushMock,
+        }}
+      />
+    );
+    expect(screen.getByText('Loading')).toBeInTheDocument();
+    await wait();
+    const submitBtn = screen.getByRole('button', { name: 'submit' });
+    expect(submitBtn).toBeDisabled();
+    userEvent.type(screen.getByLabelText(/name/), newPolicyName);
+    await wait();
+    expect(submitBtn).toBeDisabled();
+    userEvent.type(screen.getByLabelText(/cronLine/), 'foo');
+    userEvent.type(screen.getByLabelText(/description/), newPolicyDescription);
+    userEvent.selectOptions(
+      screen.getByLabelText(/ovalContentId/),
+      newPolicyContentName
+    );
+    await wait();
+    expect(screen.getByText('is not a valid cronline')).toBeInTheDocument();
+    expect(submitBtn).toBeDisabled();
+    userEvent.clear(screen.getByLabelText(/cronLine/));
+    userEvent.type(screen.getByLabelText(/cronLine/), newPolicyCronline);
+    await wait();
+    expect(
+      screen.queryByText('is not a valid cronline')
+    ).not.toBeInTheDocument();
+    expect(submitBtn).not.toBeDisabled();
+    userEvent.click(submitBtn);
+    await wait(2);
+    expect(pushMock).toHaveBeenCalledWith(ovalPoliciesPath);
+    expect(showToast).toHaveBeenCalledWith({
+      type: 'success',
+      message: 'OVAL Policy succesfully created.',
+    });
+  });
+  it('should not create new policy on validation error', async () => {
+    const showToast = jest.fn();
+    jest.spyOn(toasts, 'showToast').mockImplementation(() => showToast);
+    const pushMock = jest.fn();
+
+    render(
+      <TestComponent
+        mocks={ovalContentMocks.concat(policyValidationMock)}
+        history={{
+          push: pushMock,
+        }}
+      />
+    );
+    await wait();
+    userEvent.type(screen.getByLabelText(/name/), newPolicyName);
+    userEvent.type(screen.getByLabelText(/cronLine/), newPolicyCronline);
+    userEvent.selectOptions(
+      screen.getByLabelText(/ovalContentId/),
+      newPolicyContentName
+    );
+    await wait();
+    userEvent.click(screen.getByRole('button', { name: 'submit' }));
+    await wait(2);
+    expect(pushMock).not.toHaveBeenCalled();
+    expect(showToast).not.toHaveBeenCalled();
+    expect(screen.getByText('has already been taken')).toBeInTheDocument();
+  });
+  it('should not create policy on preconditions error', async () => {
+    const showToast = jest.fn();
+    jest.spyOn(toasts, 'showToast').mockImplementation(() => showToast);
+    const pushMock = jest.fn();
+
+    render(
+      <TestComponent
+        mocks={ovalContentMocks.concat(policyPreconditionMock)}
+        history={{
+          push: pushMock,
+        }}
+      />
+    );
+    await wait();
+    userEvent.type(screen.getByLabelText(/name/), newPolicyName);
+    userEvent.type(screen.getByLabelText(/cronLine/), newPolicyCronline);
+    userEvent.selectOptions(
+      screen.getByLabelText(/ovalContentId/),
+      newPolicyContentName
+    );
+    await wait();
+    userEvent.click(screen.getByRole('button', { name: 'submit' }));
+    await wait(2);
+    await wait();
+    expect(pushMock).not.toHaveBeenCalled();
+    expect(showToast).toHaveBeenCalledWith({
+      type: 'error',
+      message: roleAbsentCheck.failMsg,
+    });
+  });
+  it('should show hostgroup errros', async () => {
+    const showToast = jest.fn();
+    jest.spyOn(toasts, 'showToast').mockImplementation(() => showToast);
+    const pushMock = jest.fn();
+
+    render(
+      <TestComponent
+        mocks={ovalContentMocks
+          .concat(policyInvalidHgMock)
+          .concat(hostgroupsMock)}
+        history={{
+          push: pushMock,
+        }}
+      />
+    );
+    await wait();
+    userEvent.type(screen.getByLabelText(/name/), newPolicyName);
+    userEvent.type(screen.getByLabelText(/cronLine/), newPolicyCronline);
+    userEvent.selectOptions(
+      screen.getByLabelText(/ovalContentId/),
+      newPolicyContentName
+    );
+    userEvent.type(screen.getByLabelText(/hostgroup/), 'first');
+    await wait(500);
+    userEvent.click(screen.getByText(firstHg.name));
+    await wait();
+    userEvent.click(screen.getByRole('button', { name: 'submit' }));
+    await wait(2);
+    expect(pushMock).not.toHaveBeenCalled();
+    expect(screen.getByText(withoutProxyCheck.failMsg)).toBeInTheDocument();
+  });
+});

--- a/webpack/routes/OvalPolicies/OvalPoliciesNew/index.js
+++ b/webpack/routes/OvalPolicies/OvalPoliciesNew/index.js
@@ -1,0 +1,11 @@
+import React from 'react';
+import { useDispatch } from 'react-redux';
+
+import { showToast } from '../../../helpers/toastsHelper';
+import OvalPoliciesNew from './OvalPoliciesNew';
+
+const WrappedOvalPoliciesNew = props => (
+  <OvalPoliciesNew {...props} showToast={showToast(useDispatch())} />
+);
+
+export default WrappedOvalPoliciesNew;

--- a/webpack/routes/OvalPolicies/OvalPoliciesShow/CvesTable.js
+++ b/webpack/routes/OvalPolicies/OvalPoliciesShow/CvesTable.js
@@ -4,7 +4,7 @@ import { translate as __ } from 'foremanReact/common/I18n';
 
 import { linkCell } from '../../../helpers/tableHelper';
 import { hostsPath } from '../../../helpers/pathsHelper';
-import { decodeId } from '../../../helpers/globalIdHelper';
+import { decodeModelId } from '../../../helpers/globalIdHelper';
 import { addSearch } from '../../../helpers/pageParamsHelper';
 
 import withLoading from '../../../components/withLoading';
@@ -25,7 +25,7 @@ const CvesTable = props => {
 
   const hostCount = cve =>
     linkCell(
-      addSearch(hostsPath, { search: `cve_id = ${decodeId(cve)}` }),
+      addSearch(hostsPath, { search: `cve_id = ${decodeModelId(cve)}` }),
       cve.hosts.nodes.length
     );
 

--- a/webpack/routes/OvalPolicies/OvalPoliciesShow/OvalPoliciesShowHelper.js
+++ b/webpack/routes/OvalPolicies/OvalPoliciesShow/OvalPoliciesShowHelper.js
@@ -1,6 +1,5 @@
 import { translate as __, sprintf } from 'foremanReact/common/I18n';
-
-import { decodeId } from '../../../helpers/globalIdHelper';
+import { decodeModelId } from '../../../helpers/globalIdHelper';
 import { addSearch } from '../../../helpers/pageParamsHelper';
 import { newJobPath } from '../../../helpers/pathsHelper';
 
@@ -19,7 +18,9 @@ export const policySchedule = policy => {
 
 const targetingScopedSearchQuery = policy => {
   const hgIds = policy.hostgroups.nodes.reduce((memo, hg) => {
-    const ids = [decodeId(hg)].concat(hg.descendants.nodes.map(decodeId));
+    const ids = [decodeModelId(hg)].concat(
+      hg.descendants.nodes.map(decodeModelId)
+    );
     return ids.reduce(
       (acc, id) => (acc.includes(id) ? acc : [...acc, id]),
       memo

--- a/webpack/routes/routes.js
+++ b/webpack/routes/routes.js
@@ -3,6 +3,7 @@ import OvalContentsIndex from './OvalContents/OvalContentsIndex';
 import OvalContentsShow from './OvalContents/OvalContentsShow';
 import OvalContentsNew from './OvalContents/OvalContentsNew';
 import OvalPoliciesIndex from './OvalPolicies/OvalPoliciesIndex';
+import OvalPoliciesNew from './OvalPolicies/OvalPoliciesNew';
 import OvalPoliciesShow from './OvalPolicies/OvalPoliciesShow';
 
 import {
@@ -11,6 +12,7 @@ import {
   ovalContentsNewPath,
   ovalPoliciesPath,
   ovalPoliciesShowPath,
+  ovalPoliciesNewPath,
 } from '../helpers/pathsHelper';
 
 export default [
@@ -32,6 +34,11 @@ export default [
   {
     path: ovalPoliciesPath,
     render: props => <OvalPoliciesIndex {...props} />,
+    exact: true,
+  },
+  {
+    path: ovalPoliciesNewPath,
+    render: props => <OvalPoliciesNew {...props} />,
     exact: true,
   },
   {

--- a/webpack/testHelper.js
+++ b/webpack/testHelper.js
@@ -4,6 +4,7 @@ import store from 'foremanReact/redux';
 import { MockedProvider } from '@apollo/react-testing';
 import { MemoryRouter } from 'react-router-dom';
 import { getForemanContext } from 'foremanReact/Root/Context/ForemanContext';
+import { waitFor } from '@testing-library/react';
 
 export const withRedux = Component => props => (
   <Provider store={store}>
@@ -41,6 +42,14 @@ export const withMockedProvider = Component => props => {
 
 // use to resolve async mock requests for apollo MockedProvider
 export const tick = () => new Promise(resolve => setTimeout(resolve, 0));
+
+export const wait = async (tickCount = 1) => {
+  for (let i = 1; i < tickCount; i++) {
+    // eslint-disable-next-line no-await-in-loop
+    await waitFor(tick);
+  }
+  return waitFor(tick);
+};
 
 export const historyMock = {
   location: {


### PR DESCRIPTION
The minimal version of wizard that allows creating an OVAL policy. Needs cleanup, tests and handling permissions. Opening mostly for visibility so we can decide how the individual steps should look like.

General step has schedule only by cron for now, we can add other types later:
![steps-general](https://user-images.githubusercontent.com/2664090/120758616-56b94e00-c512-11eb-94d2-b2322aae8902.png)

Hostgroup selection is a second step for now. Do we want table with checkboxes? Dual select? Something else? 
![steps-hostgroups](https://user-images.githubusercontent.com/2664090/120758992-ca5b5b00-c512-11eb-8ba5-47d96eb8fbcd.png)

Thoughts about other steps? Selecting hosts?
