### PR TITLE
Fixes #33023 - destroy dependent asset_policies

### DIFF
--- a/app/models/foreman_openscap/asset.rb
+++ b/app/models/foreman_openscap/asset.rb
@@ -1,6 +1,6 @@
 module ForemanOpenscap
   class Asset < ApplicationRecord
-    has_many :asset_policies
+    has_many :asset_policies, :dependent => :destroy
     has_many :policies, :through => :asset_policies
     belongs_to :assetable, :polymorphic => true
 


### PR DESCRIPTION
We are keeping the asset_policies references in database, which prevents policies from ever being deleted.