### PR TITLE
Fixes #33137 - Align with puppet moving to a plugin

### DIFF
--- a/.github/workflows/ruby_tests.yml
+++ b/.github/workflows/ruby_tests.yml
@@ -20,6 +20,7 @@ jobs:
         foreman-core-branch: [develop]
         foreman-ansible-branch: [master]
         foreman-rex-branch: [master]
+        foreman-puppet-branch: [master]
         ruby-version: [2.5, 2.6]
     steps:
       - name: Install build packages
@@ -42,12 +43,18 @@ jobs:
           path: foreman_remote_execution
       - uses: actions/checkout@v2
         with:
+          repository: theforeman/foreman_puppet
+          ref: ${{ matrix.foreman-puppet-branch }}
+          path: foreman_puppet
+      - uses: actions/checkout@v2
+        with:
           path: foreman_openscap
       - name: Setup Bundler
         run: |
           echo "gem 'foreman_openscap', path: './foreman_openscap'" > bundler.d/foreman_openscap.local.rb
           echo "gem 'foreman_ansible', path: './foreman_ansible'" > bundler.d/foreman_ansible.local.rb
           echo "gem 'foreman_remote_execution', path: './foreman_remote_execution'" > bundler.d/foreman_remote_execution.local.rb
+          echo "gem 'foreman_puppet', path: './foreman_puppet'" > bundler.d/foreman_puppet.local.rb
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/app/helpers/policies_helper.rb
+++ b/app/helpers/policies_helper.rb
@@ -41,7 +41,7 @@ module PoliciesHelper
   end
 
   def deploy_by_radio_checked(policy, tool)
-    type = policy.deploy_by ? policy.deploy_by.to_sym : :puppet
+    type = policy.deploy_by ? policy.deploy_by.to_sym : :manual
     tool.type == type
   end
 

--- a/app/services/foreman_openscap/client_config/base.rb
+++ b/app/services/foreman_openscap/client_config/base.rb
@@ -38,6 +38,7 @@ module ForemanOpenscap
       end
 
       def find_config_item(scope = config_item_class_name.constantize)
+        return unless scope
         return scope.find_by :name => config_item_name if scope.respond_to?(:find_by)
         # all_puppetclasses, all_ansible_roles methods return Array, not ActiveRecord::Relation
         scope.find { |item| item.name == config_item_name }

--- a/app/services/foreman_openscap/client_config/puppet.rb
+++ b/app/services/foreman_openscap/client_config/puppet.rb
@@ -10,7 +10,7 @@ module ForemanOpenscap
       end
 
       def available?
-        defined?(Puppetclass)
+        defined?(ForemanPuppet)
       end
 
       def inline_help
@@ -21,13 +21,17 @@ module ForemanOpenscap
         }
       end
 
+      def collection_method
+        :puppetclasses
+      end
+
       def constants
         OpenStruct.new(
           :server_param => 'server',
           :port_param => 'port',
           :policies_param => 'policies',
           :puppetclass_name => 'foreman_scap_client',
-          :config_item_class_name => 'Puppetclass',
+          :config_item_class_name => 'ForemanPuppet::Puppetclass',
           :override_method_name => 'class_params',
           :msg_name => _('Puppet class'),
           :lookup_key_plural_name => _('Smart Class Parameters'),

--- a/db/migrate/20200117135424_migrate_port_overrides_to_int.rb
+++ b/db/migrate/20200117135424_migrate_port_overrides_to_int.rb
@@ -10,7 +10,8 @@ class MigratePortOverridesToInt < ActiveRecord::Migration[5.2]
   private
 
   def transform_lookup_values(method)
-    puppet_class = Puppetclass.find_by :name => 'foreman_scap_client'
+    return unless defined?(ForemanPuppet)
+    puppet_class = ::ForemanPuppet::Puppetclass.find_by :name => 'foreman_scap_client'
     return unless puppet_class
     port_key = puppet_class.class_params.find_by :key => 'port'
     return unless port_key

--- a/db/migrate/20201202110213_update_puppet_port_param_type.rb
+++ b/db/migrate/20201202110213_update_puppet_port_param_type.rb
@@ -10,7 +10,8 @@ class UpdatePuppetPortParamType < ActiveRecord::Migration[6.0]
   private
 
   def update_port_type(method)
-    puppet_class = Puppetclass.find_by :name => 'foreman_scap_client'
+    return unless defined?(ForemanPuppet)
+    puppet_class = ::ForemanPuppet::Puppetclass.find_by :name => 'foreman_scap_client'
     return unless puppet_class
     port_key = puppet_class.class_params.find_by :key => 'port'
     return unless port_key

--- a/test/functional/api/v2/compliance/oval_reports_controller_test.rb
+++ b/test/functional/api/v2/compliance/oval_reports_controller_test.rb
@@ -20,7 +20,7 @@ class Api::V2::Compliance::OvalReportsControllerTest < ActionController::TestCas
 
   test 'should show host errors on CVEs upload' do
     proxy = FactoryBot.create(:smart_proxy)
-    host = FactoryBot.create(:host, :puppet_proxy => proxy, :environment => FactoryBot.create(:environment))
+    host = FactoryBot.create(:host, :puppet_proxy => proxy)
     SmartProxy.any_instance.stubs(:smart_proxy_features).returns([])
     post :create, :params => @params.merge(:cname => host.name), :session => set_session_user
 

--- a/test/test_plugin_helper.rb
+++ b/test/test_plugin_helper.rb
@@ -5,6 +5,7 @@ require 'test_helper'
 FactoryBot.definition_file_paths << File.join(File.dirname(__FILE__), 'factories')
 # Add factories from foreman_ansible
 FactoryBot.definition_file_paths << File.join(ForemanAnsible::Engine.root, '/test/factories')
+FactoryBot.definition_file_paths << File.join(ForemanPuppet::Engine.root, '/test/factories')
 FactoryBot.reload
 
 require "#{ForemanOpenscap::Engine.root}/test/fixtures/cve_fixtures"
@@ -12,12 +13,12 @@ require "#{ForemanOpenscap::Engine.root}/test/fixtures/cve_fixtures"
 module ScapClientPuppetclass
   def setup_puppet_class
     puppet_config = ::ForemanOpenscap::ClientConfig::Puppet.new
-    Puppetclass.find_by(:name => puppet_config.puppetclass_name)&.destroy
+    ForemanPuppet::Puppetclass.find_by(:name => puppet_config.puppetclass_name)&.destroy
 
     puppet_class = FactoryBot.create(:puppetclass, :name => puppet_config.puppetclass_name)
-    server_param = FactoryBot.create(:puppetclass_lookup_key, :key => puppet_config.server_param, :default_value => nil)
-    port_param = FactoryBot.create(:puppetclass_lookup_key, :key => puppet_config.port_param, :default_value => nil)
-    policies_param = FactoryBot.create(:puppetclass_lookup_key, :key => puppet_config.policies_param, :default_value => nil)
+    server_param = FactoryBot.create(:puppetclass_lookup_key, :key => puppet_config.server_param, :default_value => nil, :override => false)
+    port_param = FactoryBot.create(:puppetclass_lookup_key, :key => puppet_config.port_param, :default_value => nil, :override => false)
+    policies_param = FactoryBot.create(:puppetclass_lookup_key, :key => puppet_config.policies_param, :default_value => nil, :override => false)
 
     env = FactoryBot.create :environment
 

--- a/test/unit/policy_test.rb
+++ b/test/unit/policy_test.rb
@@ -75,7 +75,6 @@ class PolicyTest < ActiveSupport::TestCase
     asset = FactoryBot.create(:asset, :assetable_id => hg.id, :assetable_type => 'Hostgroup')
     policy = FactoryBot.create(:policy, :assets => [asset], :scap_content => @scap_content, :scap_content_profile => @scap_profile)
     policy.save!
-    hg.hostgroup_classes.destroy_all
     hg.destroy
     assert_equal 0, policy.hostgroups.count
   end

--- a/test/unit/services/hostgroup_overrider_test.rb
+++ b/test/unit/services/hostgroup_overrider_test.rb
@@ -13,7 +13,7 @@ class HostgroupOverriderTest < ActiveSupport::TestCase
 
     proxy = FactoryBot.create(:openscap_proxy, :url => 'https://override-keys.example.com:8998')
 
-    hostgroup = FactoryBot.create(:hostgroup, :environment_id => env.id, :openscap_proxy_id => proxy.id)
+    hostgroup = FactoryBot.create(:hostgroup, :environment_id => env.id, :openscap_proxy_id => proxy.id, :puppet => FactoryBot.create(:hostgroup_puppet_facet))
     refute hostgroup.puppetclasses.include? puppet_class
     assert LookupValue.where(:match => "hostgroup=#{hostgroup.to_label}",
                              :lookup_key_id => port_param.id,

--- a/test/unit/services/lookup_key_overrider_test.rb
+++ b/test/unit/services/lookup_key_overrider_test.rb
@@ -21,7 +21,7 @@ class LookupKeyOverriderTest < ActiveSupport::TestCase
   end
 
   test 'should add error when no puppet class found' do
-    puppet_class = Puppetclass.find_by :name => ForemanOpenscap::ClientConfig::Puppet.new.puppetclass_name
+    puppet_class = ::ForemanPuppet::Puppetclass.find_by :name => ForemanOpenscap::ClientConfig::Puppet.new.puppetclass_name
     puppet_class.destroy if puppet_class
     policy = FactoryBot.create(:policy, :scap_content => @scap_content, :scap_content_profile => @scap_content_profile, :deploy_by => :puppet)
     ForemanOpenscap::LookupKeyOverrider.new(policy).override


### PR DESCRIPTION
Since the plan is to have foreman_puppet installed for both new and existing users on 3.0, we do not need to switch policy deploy type just yet.