### PR TITLE
Fixes #28609 - Remove fix for skipping lone taxonomies assignment

### DIFF
--- a/app/controllers/api/v2/compliance/arf_reports_controller.rb
+++ b/app/controllers/api/v2/compliance/arf_reports_controller.rb
@@ -140,12 +140,6 @@ module Api
             super
           end
         end
-
-        protected
-
-        def assign_lone_taxonomies
-          # do not assign lone taxonomies to arf report
-        end
       end
     end
   end


### PR DESCRIPTION
Assigning lone taxonomies was fixed in core, we can now remove the fix we have in arf_reports_controller.