### PR TITLE
Fixes #33309 - drop unused tables

### DIFF
--- a/db/migrate/20210819143316_drop_unused_tables.rb
+++ b/db/migrate/20210819143316_drop_unused_tables.rb
@@ -1,0 +1,6 @@
+class DropUnusedTables < ActiveRecord::Migration[6.0]
+  def up
+    drop_table :foreman_openscap_arf_reports
+    drop_table :foreman_openscap_arf_report_raws
+  end
+end


### PR DESCRIPTION
There are some unused tables that were dropped in a migration:

https://github.com/theforeman/foreman_openscap/pull/135/files#diff-b1b8ca09732f5fb87f52b12f0ef7034abcef4b6d6c930d7f2a6712618d6e43c3R50-R55

However after the commit was merged, migration was transformed to a rake task:

https://github.com/theforeman/foreman_openscap/pull/155

This rake task is not automatically called, so if you install OpenSCAP plugin today (2021) and from scratch, those tables are still there and empty. This patch removes them, users who migrated had plenty of time to perform data migration to the new format.

Edit: Looks like some tables were already deleted but two were still there:

```
== 20210819143316 DropUnusedTables: migrating =================================
-- table_exists?("foreman_openscap_arf_report_breakdowns")
   -> 0.0007s
-- table_exists?(:foreman_openscap_xccdf_results)
   -> 0.0004s
-- table_exists?(:foreman_openscap_xccdf_rules)
   -> 0.0003s
-- table_exists?(:foreman_openscap_xccdf_rule_results)
   -> 0.0003s
-- drop_table(:foreman_openscap_arf_reports)
   -> 0.0011s
-- drop_table(:foreman_openscap_arf_report_raws)
   -> 0.0005s
== 20210819143316 DropUnusedTables: migrated (0.0036s) ========================
```