### PR TITLE
Refs #33137 - tests work without Puppet plugin

### DIFF
--- a/test/functional/api/v2/compliance/policies_controller_test.rb
+++ b/test/functional/api/v2/compliance/policies_controller_test.rb
@@ -40,6 +40,7 @@ class Api::V2::Compliance::PoliciesControllerTest < ActionController::TestCase
   end
 
   test "should get index and show hostgroups" do
+    skip unless puppet_available?
     ForemanOpenscap::Policy.any_instance.stubs(:find_scap_puppetclass).returns(FactoryBot.create(:puppetclass, :name => 'foreman_scap_client'))
     ForemanOpenscap::Policy.any_instance.stubs(:populate_overrides)
     hostgroup = FactoryBot.create(:hostgroup)
@@ -61,6 +62,7 @@ class Api::V2::Compliance::PoliciesControllerTest < ActionController::TestCase
   end
 
   test "should show a policy hosts and hostgroups" do
+    skip unless puppet_available?
     ForemanOpenscap::Policy.any_instance.stubs(:find_scap_puppetclass).returns(FactoryBot.create(:puppetclass, :name => 'foreman_scap_client'))
     ForemanOpenscap::Policy.any_instance.stubs(:populate_overrides)
     hostgroup = FactoryBot.create(:hostgroup)

--- a/test/test_plugin_helper.rb
+++ b/test/test_plugin_helper.rb
@@ -5,12 +5,16 @@ require 'test_helper'
 FactoryBot.definition_file_paths << File.join(File.dirname(__FILE__), 'factories')
 # Add factories from foreman_ansible
 FactoryBot.definition_file_paths << File.join(ForemanAnsible::Engine.root, '/test/factories')
-FactoryBot.definition_file_paths << File.join(ForemanPuppet::Engine.root, '/test/factories')
+FactoryBot.definition_file_paths << File.join(ForemanPuppet::Engine.root, '/test/factories') if defined?(ForemanPuppet)
 FactoryBot.reload
 
 require "#{ForemanOpenscap::Engine.root}/test/fixtures/cve_fixtures"
 
 module ScapClientPuppetclass
+  def puppet_available?
+    defined?(ForemanPuppet)
+  end
+
   def setup_puppet_class
     puppet_config = ::ForemanOpenscap::ClientConfig::Puppet.new
     ForemanPuppet::Puppetclass.find_by(:name => puppet_config.puppetclass_name)&.destroy

--- a/test/unit/policy_test.rb
+++ b/test/unit/policy_test.rb
@@ -313,6 +313,7 @@ class PolicyTest < ActiveSupport::TestCase
   end
 
   test "should change deploy type" do
+    skip unless puppet_available?
     policy = FactoryBot.create(:policy, :scap_content => @scap_content, :scap_content_profile => @scap_profile)
     setup_puppet_class
     policy.change_deploy_type({ :deploy_by => 'puppet' })

--- a/test/unit/services/config_name_service_test.rb
+++ b/test/unit/services/config_name_service_test.rb
@@ -24,6 +24,7 @@ class ConfigNameServiceTest < ActiveSupport::TestCase
   end
 
   test 'should find all available except Manual' do
+    skip unless puppet_available?
     ForemanOpenscap::ClientConfig::Ansible.any_instance.stubs(:available?).returns(false)
     configs = @name_service.all_available_except(:manual)
     assert_equal 1, configs.size

--- a/test/unit/services/hostgroup_overrider_test.rb
+++ b/test/unit/services/hostgroup_overrider_test.rb
@@ -9,6 +9,7 @@ class HostgroupOverriderTest < ActiveSupport::TestCase
   end
 
   test 'should populate puppet overrides' do
+    skip unless puppet_available?
     puppet_class, env, port_param, server_param = setup_puppet_class.values_at :puppet_class, :env, :port_param, :server_param
 
     proxy = FactoryBot.create(:openscap_proxy, :url => 'https://override-keys.example.com:8998')

--- a/test/unit/services/lookup_key_overrider_test.rb
+++ b/test/unit/services/lookup_key_overrider_test.rb
@@ -8,6 +8,7 @@ class LookupKeyOverriderTest < ActiveSupport::TestCase
   end
 
   test 'should override puppet class parameters' do
+    skip unless puppet_available?
     server_param, port_param, policies_param = setup_puppet_class.values_at :server_param, :port_param, :policies_param
     refute server_param.override
     refute port_param.override
@@ -21,6 +22,7 @@ class LookupKeyOverriderTest < ActiveSupport::TestCase
   end
 
   test 'should add error when no puppet class found' do
+    skip unless puppet_available?
     puppet_class = ::ForemanPuppet::Puppetclass.find_by :name => ForemanOpenscap::ClientConfig::Puppet.new.puppetclass_name
     puppet_class.destroy if puppet_class
     policy = FactoryBot.create(:policy, :scap_content => @scap_content, :scap_content_profile => @scap_content_profile, :deploy_by => :puppet)
@@ -41,6 +43,7 @@ class LookupKeyOverriderTest < ActiveSupport::TestCase
   end
 
   test 'should add error when lookup keys not present' do
+    skip unless puppet_available?
     server_param, port_param, policies_param = setup_puppet_class.values_at :server_param, :port_param, :policies_param
     server_param.destroy
     port_param.destroy


### PR DESCRIPTION
Tests do fail without Puppet plugin installed. This fixes it.