### PR TITLE
Fixes #34134 - removing the increment on the day of the week

### DIFF
--- a/app/models/concerns/foreman_openscap/policy_common.rb
+++ b/app/models/concerns/foreman_openscap/policy_common.rb
@@ -69,7 +69,7 @@ module ForemanOpenscap
 
     def weekday_number
       # 0 is sunday, 1 is monday in cron, while DAYS_INTO_WEEK has 0 as monday, 6 as sunday
-      (Date::DAYS_INTO_WEEK.with_indifferent_access[weekday] + 1) % 7
+      (Date::DAYS_INTO_WEEK.with_indifferent_access[weekday]) % 7
     end
   end
 end


### PR DESCRIPTION
Before version 6 it was necessary to make the increment now it is no longer due to the API upgrade
Monday is starting now with the value 1 which was previously the value 0