### PR TITLE
rubocop fixes

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -178,3 +178,6 @@ Rails/ReadWriteAttribute:
 Rails/TimeZone:
   Exclude:
     - 'app/models/foreman_openscap/arf_report.rb'
+
+Rails/HasManyOrHasOneDependent:
+  Enabled: false


### PR DESCRIPTION
the error was `Rails/HasManyOrHasOneDependent: Specify a :dependent option.`