### PR TITLE
Fixes #34385 - more reliable way of detecting Ansible plugin

### DIFF
--- a/app/services/foreman_openscap/client_config/ansible.rb
+++ b/app/services/foreman_openscap/client_config/ansible.rb
@@ -16,7 +16,7 @@ module ForemanOpenscap
       end
 
       def available?
-        defined?(ForemanAnsible)
+        Foreman::Plugin.installed?("foreman_ansible")
       end
 
       def inline_help

--- a/db/migrate/20200803065041_migrate_port_overrides_for_ansible.rb
+++ b/db/migrate/20200803065041_migrate_port_overrides_for_ansible.rb
@@ -10,7 +10,7 @@ class MigratePortOverridesForAnsible < ActiveRecord::Migration[6.0]
   private
 
   def transform_lookup_values(method)
-    return unless defined?(ForemanAnsible)
+    return unless Foreman::Plugin.installed?("foreman_ansible")
     role = AnsibleRole.find_by :name => 'theforeman.foreman_scap_client'
     return unless role
     port_key = role.ansible_variables.find_by :key => 'foreman_scap_client_port'


### PR DESCRIPTION
After the ForemanAnsible namespace has been defined in the Foreman core,
we need to use something more reliable to detect the plugin presence.
The version is always defined only in the plugin gem.