### PR TITLE
use Ruby 2.7 for tests

### DIFF
--- a/.github/workflows/ruby_tests.yml
+++ b/.github/workflows/ruby_tests.yml
@@ -21,7 +21,7 @@ jobs:
         foreman-ansible-branch: [master]
         foreman-rex-branch: [master]
         foreman-puppet-branch: [master]
-        ruby-version: [2.5, 2.6]
+        ruby-version: [2.5, 2.7]
     steps:
       - name: Install build packages
         run: |


### PR DESCRIPTION
Foreman is currently using 2.5 and 2.7 in prod deployments, not 2.6