### PR TITLE
Fixes #36110 - do not try to load removed JS file

### DIFF
--- a/app/views/smart_proxies/plugins/_openscap.html.erb
+++ b/app/views/smart_proxies/plugins/_openscap.html.erb
@@ -1,4 +1,3 @@
-<%= javascript 'foreman_openscap/openscap_proxy' %>
 <div class="row">
   <h3><%= feature %></h3>
 </div>


### PR DESCRIPTION
The file was removed in ada67f6b75e1df3b119ab5453d9e43c28fcc8773 but the reference to it was not. Let's fix that.

Fixes: ada67f6b75e1df3b119ab5453d9e43c28fcc8773