### PR TITLE
Bump version 6.0.0 and requires_foreman '>= 3.3'

### DIFF
--- a/lib/foreman_openscap/engine.rb
+++ b/lib/foreman_openscap/engine.rb
@@ -48,7 +48,7 @@ module ForemanOpenscap
 
     initializer 'foreman_openscap.register_plugin', :before => :finisher_hook do |app|
       Foreman::Plugin.register :foreman_openscap do
-        requires_foreman '>= 1.24'
+        requires_foreman '>= 3.3'
 
         apipie_documented_controllers ["#{ForemanOpenscap::Engine.root}/app/controllers/api/v2/compliance/*.rb"]
 

--- a/lib/foreman_openscap/version.rb
+++ b/lib/foreman_openscap/version.rb
@@ -1,3 +1,3 @@
 module ForemanOpenscap
-  VERSION = "5.2.3".freeze
+  VERSION = "6.0.0".freeze
 end


### PR DESCRIPTION
commit 777d809efe664ec089b786aa1745749f94325fdd updated the package.json to a version which is used by foreman 3.3