### PR TITLE
Fixes #36422 - do not load non-existant charts.js

### DIFF
--- a/app/views/arf_reports/show.html.erb
+++ b/app/views/arf_reports/show.html.erb
@@ -1,4 +1,3 @@
-<% javascript 'charts' %>
 <% javascript 'foreman_openscap/reports' %>
 <% stylesheet 'foreman_openscap/reports' %>
 

--- a/app/views/compliance_hosts/show.html.erb
+++ b/app/views/compliance_hosts/show.html.erb
@@ -1,4 +1,4 @@
-<% javascript 'charts', 'foreman_openscap/scap_hosts_show' %>
+<% javascript 'foreman_openscap/scap_hosts_show' %>
 <% stylesheet 'foreman_openscap/scap_breakdown_chart' %>
 
 <%= breadcrumbs(:resource_url => api_hosts_path,

--- a/app/views/policy_dashboard/index.html.erb
+++ b/app/views/policy_dashboard/index.html.erb
@@ -1,4 +1,4 @@
-<% javascript 'charts', 'foreman_openscap/policy_dashboard' %>
+<% javascript 'foreman_openscap/policy_dashboard' %>
 
 <% title _("Compliance policy: %s") % @policy.name %>
 


### PR DESCRIPTION
We used charts.js from Foreman, but that was dropped in Foreman 3.0 (https://github.com/theforeman/foreman/commit/69379b51a33344de93836950565ecbfae0c4df23) and results in 404 errors when trying to load some pages