### PR TITLE
Fixes #36838 - Make doc links point to the new docs

### DIFF
--- a/app/helpers/foreman_openscap_helper.rb
+++ b/app/helpers/foreman_openscap_helper.rb
@@ -16,7 +16,7 @@ module ForemanOpenscapHelper
   end
 
   def doc_flavor
-    ::Foreman::Plugin.installed?('katello') ? 'katello' : 'foreman'
+    ForemanOpenscap.with_katello? ? 'katello' : 'foreman'
   end
 
   def scap_root_url

--- a/app/helpers/foreman_openscap_helper.rb
+++ b/app/helpers/foreman_openscap_helper.rb
@@ -1,12 +1,8 @@
 require 'foreman_openscap/version'
 
 module ForemanOpenscapHelper
-  def scap_doc_link(section = '', text = _('documentation'))
-    link_to(
-      text,
-      scap_doc_url(section),
-      :rel => 'external noopener noreferrer', :target => '_blank'
-    )
+  def scap_doc_button(section)
+    documentation_button(section, root_url: scap_doc_url)
   end
 
   def scap_doc_url(section = '')
@@ -14,6 +10,8 @@ module ForemanOpenscapHelper
 
     documentation_url(section, root_url: scap_root_url)
   end
+
+  private
 
   def doc_flavor
     ForemanOpenscap.with_katello? ? 'katello' : 'foreman-el'

--- a/app/helpers/foreman_openscap_helper.rb
+++ b/app/helpers/foreman_openscap_helper.rb
@@ -15,11 +15,15 @@ module ForemanOpenscapHelper
     documentation_url(section, root_url: scap_root_url)
   end
 
+  def doc_flavor
+    ::Foreman::Plugin.installed?('katello') ? 'katello' : 'foreman'
+  end
+
   def scap_root_url
     @scap_root_url ||= begin
       version = SETTINGS[:version]
       version = version.tag == 'develop' ? 'nightly' : version.short
-      "https://docs.theforeman.org/#{version}/Managing_Security_Compliance/index-foreman-el.html#"
+      "https://docs.theforeman.org/#{version}/Managing_Security_Compliance/index-#{doc_flavor}-el.html#"
     end
   end
 end

--- a/app/helpers/foreman_openscap_helper.rb
+++ b/app/helpers/foreman_openscap_helper.rb
@@ -16,14 +16,14 @@ module ForemanOpenscapHelper
   end
 
   def doc_flavor
-    ForemanOpenscap.with_katello? ? 'katello' : 'foreman'
+    ForemanOpenscap.with_katello? ? 'katello' : 'foreman-el'
   end
 
   def scap_root_url
     @scap_root_url ||= begin
       version = SETTINGS[:version]
       version = version.tag == 'develop' ? 'nightly' : version.short
-      "https://docs.theforeman.org/#{version}/Managing_Security_Compliance/index-#{doc_flavor}-el.html#"
+      "https://docs.theforeman.org/#{version}/Managing_Security_Compliance/index-#{doc_flavor}.html#"
     end
   end
 end

--- a/app/helpers/foreman_openscap_helper.rb
+++ b/app/helpers/foreman_openscap_helper.rb
@@ -18,7 +18,7 @@ module ForemanOpenscapHelper
   def scap_root_url
     @scap_root_url ||= begin
       version = ForemanOpenscap::VERSION.split('.')[0..-2].join('.')
-      "https://theforeman.org/plugins/foreman_openscap/#{version}/index.html"
+      "https://docs.theforeman.org/#{SETTINGS[:version].short}/Managing_Security_Compliance/index-foreman-el.html#"
     end
   end
 end

--- a/app/helpers/foreman_openscap_helper.rb
+++ b/app/helpers/foreman_openscap_helper.rb
@@ -17,8 +17,9 @@ module ForemanOpenscapHelper
 
   def scap_root_url
     @scap_root_url ||= begin
-      version = ForemanOpenscap::VERSION.split('.')[0..-2].join('.')
-      "https://docs.theforeman.org/#{SETTINGS[:version].short}/Managing_Security_Compliance/index-foreman-el.html#"
+      version = SETTINGS[:version]
+      version = version.tag == 'develop' ? 'nightly' : version.short
+      "https://docs.theforeman.org/#{version}/Managing_Security_Compliance/index-foreman-el.html#"
     end
   end
 end

--- a/app/views/arf_reports/welcome.html.erb
+++ b/app/views/arf_reports/welcome.html.erb
@@ -9,6 +9,6 @@
     <%= _("You don't seem to have any ARF report. ARF report is a summary of a single scan occurrence on a particular host for a given Compliance Policy.") %></br>
   </p>
   <div class="blank-slate-pf-main-action">
-    <%= link_to _('Documentation'), documentation_url("4.4ARFReports", :root_url => "https://www.theforeman.org/plugins/foreman_openscap/0.8/index.html#"), :rel => 'external', :class => 'btn btn-primary btn-lg'  %>
+    <%= link_to _('Documentation'), documentation_url("Monitoring_Compliance_security-compliance", :root_url => scap_doc_url), :rel => 'external', :class => 'btn btn-primary btn-lg'  %>
   </div>
 </div>

--- a/app/views/arf_reports/welcome.html.erb
+++ b/app/views/arf_reports/welcome.html.erb
@@ -9,6 +9,6 @@
     <%= _("You don't seem to have any ARF report. ARF report is a summary of a single scan occurrence on a particular host for a given Compliance Policy.") %></br>
   </p>
   <div class="blank-slate-pf-main-action">
-    <%= link_to _('Documentation'), documentation_url("Monitoring_Compliance_security-compliance", :root_url => scap_doc_url), :rel => 'external', :class => 'btn btn-primary btn-lg'  %>
+    <%= link_to _('Documentation'), scap_doc_url("Monitoring_Compliance_security-compliance"), :rel => 'external', :class => 'btn btn-primary btn-lg'  %>
   </div>
 </div>

--- a/app/views/policies/index.html.erb
+++ b/app/views/policies/index.html.erb
@@ -3,7 +3,7 @@
 
 <% title_actions(
   display_link_if_authorized(_("New Compliance Policy"), hash_for_new_policy_path, :class => "btn btn-primary"),
-    documentation_button('#4.2Creatingpolicywizard', :root_url => scap_doc_url)
+    documentation_button('Managing_Compliance_Policies_security-compliance', :root_url => scap_doc_url)
   ) %>
 
 <%= render :partial => 'list' %>

--- a/app/views/policies/index.html.erb
+++ b/app/views/policies/index.html.erb
@@ -3,7 +3,7 @@
 
 <% title_actions(
   display_link_if_authorized(_("New Compliance Policy"), hash_for_new_policy_path, :class => "btn btn-primary"),
-    documentation_button('Managing_Compliance_Policies_security-compliance', :root_url => scap_doc_url)
+    scap_doc_button('Managing_Compliance_Policies_security-compliance')
   ) %>
 
 <%= render :partial => 'list' %>

--- a/app/views/policies/steps/_deployment_options_form.html.erb
+++ b/app/views/policies/steps/_deployment_options_form.html.erb
@@ -4,7 +4,7 @@
   <div class="alert alert-info" id="scap-deployment-options-info-banner">
     <span class="pficon pficon-info"></span>
     <strong><%= _('There are significant differences in deployment options.') %></strong>
-    <%= _('Please make sure you understand them by reading our') %> <%=scap_doc_link('#2.3Policydeploymentoptions') %>.
+    <%= _('Please make sure you understand them by reading our') %> <%= link_to(_('documentation'), scap_doc_url('deploying-compliance-policies_security-compliance'), :rel => 'external noopener noreferrer', :target => '_blank') %>.
   </div>
 
   <%= deploy_by_radios f, @policy %>

--- a/app/views/scap_contents/index.html.erb
+++ b/app/views/scap_contents/index.html.erb
@@ -1,6 +1,6 @@
 <% title _("SCAP Contents") %>
 
 <% title_actions(display_link_if_authorized(_("Upload New SCAP Content"), hash_for_new_scap_content_path, :class => 'btn btn-primary'),
-                 documentation_button('Configuring_SCAP_Contents_security-compliance', :root_url => scap_doc_url)) %>
+                 scap_doc_button('Configuring_SCAP_Contents_security-compliance')) %>
 
 <%= render :partial => 'list' %>

--- a/app/views/scap_contents/index.html.erb
+++ b/app/views/scap_contents/index.html.erb
@@ -1,6 +1,6 @@
 <% title _("SCAP Contents") %>
 
 <% title_actions(display_link_if_authorized(_("Upload New SCAP Content"), hash_for_new_scap_content_path, :class => 'btn btn-primary'),
-                 documentation_button('#4.1CreatingSCAPcontent', :root_url => scap_doc_url)) %>
+                 documentation_button('Configuring_SCAP_Contents_security-compliance', :root_url => scap_doc_url)) %>
 
 <%= render :partial => 'list' %>

--- a/app/views/tailoring_files/index.html.erb
+++ b/app/views/tailoring_files/index.html.erb
@@ -1,4 +1,4 @@
 <% title _("Tailoring Files") %>
 <% title_actions(display_link_if_authorized(_("Upload New Tailoring file"), hash_for_new_tailoring_file_path, :class => 'btn btn-primary'),
-                documentation_button('tailoring-xccdf-profiles_security-compliance', :root_url => scap_doc_url)) %>
+                scap_doc_button('tailoring-xccdf-profiles_security-compliance')) %>
 <%= render :partial => 'list' %>

--- a/app/views/tailoring_files/index.html.erb
+++ b/app/views/tailoring_files/index.html.erb
@@ -1,4 +1,4 @@
 <% title _("Tailoring Files") %>
 <% title_actions(display_link_if_authorized(_("Upload New Tailoring file"), hash_for_new_tailoring_file_path, :class => 'btn btn-primary'),
-                documentation_button('#4.5Tailoringfiles(foreman_openscap>=0.6.5)', :root_url => scap_doc_url)) %>
+                documentation_button('tailoring-xccdf-profiles_security-compliance', :root_url => scap_doc_url)) %>
 <%= render :partial => 'list' %>


### PR DESCRIPTION
I know this isn't exactly clean, but this should get cherrypicked all the way back into a 3.6-compatible branch so we can't really add some nice infrastructure into Foreman itself and then use it here without making things hard for ourselves.