### PR TITLE
Fixes #27259 - Fix hostgroup-asset association

### DIFF
--- a/app/models/concerns/foreman_openscap/hostgroup_extensions.rb
+++ b/app/models/concerns/foreman_openscap/hostgroup_extensions.rb
@@ -5,8 +5,8 @@ module ForemanOpenscap
     include InheritedPolicies
 
     included do
-      has_one :asset, :as => :assetable, :class_name => "::ForemanOpenscap::Asset", dependent: :destroy
-      has_many :asset_policies, :through => :asset, :class_name => "::ForemanOpenscap::AssetPolicy"
+      has_many :assets, :as => :assetable, :class_name => "::ForemanOpenscap::Asset", dependent: :destroy
+      has_many :asset_policies, :through => :assets, :class_name => "::ForemanOpenscap::AssetPolicy"
       has_many :policies, :through => :asset_policies, :class_name => "::ForemanOpenscap::Policy"
     end
 

--- a/test/unit/concerns/hostgroup_extensions_test.rb
+++ b/test/unit/concerns/hostgroup_extensions_test.rb
@@ -1,0 +1,10 @@
+require 'test_plugin_helper'
+
+class HostgroupExtensionsTest < ActiveSupport::TestCase
+  test "should remove all linked assets on hostgroup destroy" do
+    hostgroup = FactoryBot.create(:hostgroup)
+    FactoryBot.create_list(:asset, 3, :assetable_id => hostgroup.id, :assetable_type => 'Hostgroup')
+    asset_scope = ::ForemanOpenscap::Asset.where(:assetable_id => hostgroup.id, :assetable_type => 'Hostgroup')
+    assert_difference("asset_scope.count", -3) { hostgroup.destroy }
+  end
+end


### PR DESCRIPTION
Because of the wrong cardinality, only first asset got removed on hostgroup destroy, leading to orphaned assets being left around.