### PR TITLE
Fixes #37460 - Use weights for host columns in wizard

### DIFF
--- a/webpack/components/OpenscapRemediationWizard/steps/ReviewHosts.js
+++ b/webpack/components/OpenscapRemediationWizard/steps/ReviewHosts.js
@@ -1,3 +1,4 @@
+/* eslint-disable camelcase */
 import React, { useContext, useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import {
@@ -160,11 +161,18 @@ const ReviewHosts = () => {
   const columns = {
     name: {
       title: __('Name'),
-      wrapper: ({ id, name }) => <a href={foremanUrl(`hosts/${id}`)}>{name}</a>,
+      wrapper: ({ id, display_name: displayName }) => (
+        <a href={foremanUrl(`hosts/${id}`)}>{displayName}</a>
+      ),
       isSorted: true,
+      weight: 50,
+      isRequired: true,
     },
-    operatingsystem_name: {
+    os_title: {
       title: __('OS'),
+      wrapper: hostDetails => hostDetails?.operatingsystem_name,
+      isSorted: true,
+      weight: 200,
     },
   };
 


### PR DESCRIPTION
I've mostly copy-pasted column definitions (with some adjustments) from https://github.com/theforeman/foreman/blob/develop/webpack/assets/javascripts/react_app/components/HostsIndex/Columns/core.js


Also, I think that ideally we'd want to support user preferences as well, something like https://github.com/theforeman/foreman/blob/develop/webpack/assets/javascripts/react_app/components/HostsIndex/index.js#L100. But that should be done as a separate PR after the stuff in core is more stable. I opened an issue to track that https://projects.theforeman.org/issues/37462. Although, the table might be pretty populated with columns, I'd say that might also help users to actually understand what host is affected. Host name and OS seem to be quite lacking information.