### PR TITLE
Use documentation URL helper from core

### DIFF
--- a/app/helpers/foreman_openscap_helper.rb
+++ b/app/helpers/foreman_openscap_helper.rb
@@ -2,26 +2,10 @@ require 'foreman_openscap/version'
 
 module ForemanOpenscapHelper
   def scap_doc_button(section)
-    documentation_button(section, root_url: scap_doc_url)
+    documentation_button('Managing_Security_Compliance', type: 'docs', chapter: section)
   end
 
   def scap_doc_url(section = '')
-    return scap_root_url if section.empty?
-
-    documentation_url(section, root_url: scap_root_url)
-  end
-
-  private
-
-  def doc_flavor
-    ForemanOpenscap.with_katello? ? 'katello' : 'foreman-el'
-  end
-
-  def scap_root_url
-    @scap_root_url ||= begin
-      version = SETTINGS[:version]
-      version = version.tag == 'develop' ? 'nightly' : version.short
-      "https://docs.theforeman.org/#{version}/Managing_Security_Compliance/index-#{doc_flavor}.html#"
-    end
+    documentation_url('Managing_Security_Compliance', type: 'docs', chapter: section)
   end
 end


### PR DESCRIPTION
Foreman 3.9.1+ has built in support to link to docs. This simplifies the code in this module.

There is some downstream branding consideration. Either https://github.com/RedHatSatellite/foreman_theme_satellite/blob/bf42fb119af723df5080e9b5d0f73fd8c483e017/lib/foreman_theme_satellite/documentation.rb#L67-L72 needs to be updated or https://github.com/RedHatSatellite/foreman_theme_satellite/pull/58 needs to be merged.