### PR TITLE
Fixes #37961 - Mark ansible as job template requirement

### DIFF
--- a/app/views/job_templates/run_openscap_remediation_-_ansible_default.erb
+++ b/app/views/job_templates/run_openscap_remediation_-_ansible_default.erb
@@ -16,6 +16,8 @@ template_inputs:
   description: Indicate wether the host should be rebooted after all the remediation
   input_type: user
   required: false
+require:
+- plugin: foreman_ansible
 %>
 ---
 - hosts: all


### PR DESCRIPTION
This will prevent the job template from being seeded if ansible plugin is not available.

Soft requires https://github.com/theforeman/foreman_remote_execution/pull/923 . Without it, this won't do anything, but also won't break anything.