### PR TITLE
Fixes #37995 - High memory rendering Arf Report index page

### DIFF
--- a/app/controllers/arf_reports_controller.rb
+++ b/app/controllers/arf_reports_controller.rb
@@ -10,9 +10,15 @@ class ArfReportsController < ApplicationController
   end
 
   def index
+    # Avoid using includes() with nested associations and "order by" together. Otherwise,
+    # includes() will use join tables instead and Rails somehow create many objects and
+    # high memory consumption.
+    @arf_reports_pg = resource_base.search_for(params[:search], :order => params[:order])
+                                   .paginate(:page => params[:page], :per_page => params[:per_page])
+    arf_report_ids = @arf_reports_pg.pluck(:id)
     @arf_reports = resource_base.includes(:policy, :openscap_proxy, :host => %i[policies last_report_object host_statuses])
-                                .search_for(params[:search], :order => params[:order])
-                                .paginate(:page => params[:page], :per_page => params[:per_page])
+                                .where(id: arf_report_ids)
+                                .sort_by{ |arf_report| arf_report_ids.index(arf_report.id) }
   end
 
   def show

--- a/app/controllers/arf_reports_controller.rb
+++ b/app/controllers/arf_reports_controller.rb
@@ -18,7 +18,7 @@ class ArfReportsController < ApplicationController
     arf_report_ids = @arf_reports_pg.pluck(:id)
     @arf_reports = resource_base.includes(:policy, :openscap_proxy, :host => %i[policies last_report_object host_statuses])
                                 .where(id: arf_report_ids)
-                                .sort_by{ |arf_report| arf_report_ids.index(arf_report.id) }
+                                .sort_by { |arf_report| arf_report_ids.index(arf_report.id) }
   end
 
   def show

--- a/app/views/arf_reports/_list.html.erb
+++ b/app/views/arf_reports/_list.html.erb
@@ -56,4 +56,4 @@
     </div>
   </div>
 </div>
-<%= will_paginate_with_info @arf_reports %>
+<%= will_paginate_with_info @arf_reports_pg %>


### PR DESCRIPTION
Avoid using includes() with nested associations and "order by"  together. Otherwise, includes() will use join tables instead and Rails somehow create many objects and high memory consumption.

For more information, please refer to https://projects.theforeman.org/issues/37995