### PR TITLE
Fixes #38380 - remediations enable usr-overlay for bootc hosts

### DIFF
--- a/app/views/job_templates/run_openscap_remediation_-_ansible_default.erb
+++ b/app/views/job_templates/run_openscap_remediation_-_ansible_default.erb
@@ -22,22 +22,16 @@ require:
 ---
 - hosts: all
   tasks:
-    - name: Collect bootc status
-      shell:
-        cmd: 'bootc status --json'
-      register: bootc_status
-      ignore_errors: true
-    - name: Parse bootc status json
-      set_fact:
-        bootc_status_json: "{{ bootc_status.stdout | from_json }}"
-      when: bootc_status.rc == 0
+<%= indent(4) { snippet('check_bootc_status') } %>
     - name: Enable bootc overlay
       shell:
         cmd: 'bootc usr-overlay'
       register: out
       ignore_errors: true
-      when: bootc_status_json is defined and bootc_status_json['status']['booted'] != 'null'
+      when: is_bootc_host
     - debug: var=out
+      when: is_bootc_host
+<%= indent(4) { input('tasks') } -%>
 <% if truthy?(input('reboot')) %>
     - name: Reboot the machine
       reboot:

--- a/app/views/job_templates/run_openscap_remediation_-_ansible_default.erb
+++ b/app/views/job_templates/run_openscap_remediation_-_ansible_default.erb
@@ -22,7 +22,22 @@ require:
 ---
 - hosts: all
   tasks:
-<%= indent(4) { input('tasks') } -%>
+    - name: Collect bootc status
+      shell:
+        cmd: 'bootc status --json'
+      register: bootc_status
+      ignore_errors: true
+    - name: Parse bootc status json
+      set_fact:
+        bootc_status_json: "{{ bootc_status.stdout | from_json }}"
+      when: bootc_status.rc == 0
+    - name: Enable bootc overlay
+      shell:
+        cmd: 'bootc usr-overlay'
+      register: out
+      ignore_errors: true
+      when: bootc_status_json is defined and bootc_status_json['status']['booted'] != 'null'
+    - debug: var=out
 <% if truthy?(input('reboot')) %>
     - name: Reboot the machine
       reboot:

--- a/app/views/job_templates/run_openscap_remediation_-_script_default.erb
+++ b/app/views/job_templates/run_openscap_remediation_-_script_default.erb
@@ -17,6 +17,9 @@ template_inputs:
   input_type: user
   required: false
 %>
+<% if @host.respond_to?(:image_mode_host?) && @host.image_mode_host? -%>
+bootc usr-overlay
+<% end -%>
 <%= input('command') %>
 <% if truthy?(input('reboot')) -%>
 echo "A reboot is required to finish the remediation. The system is going to reboot now."


### PR DESCRIPTION
Adds a step to enable the usr-overlay for image mode hosts. Only works if the Katello plugin is installed.

Note: while we can enable the usr-overlay, for now, the package module will try using the atomic package manager, which will fail. Trying to edit playbooks sounds very risky, so we'll need to rely on the Ansible package module being fixed in the future (or the OpenSCAP playbooks).

Required: https://github.com/Katello/katello/pull/11374/