### PR TITLE
Fixes #38513 - use dnf for remediations on bootc machines

### DIFF
--- a/app/views/job_templates/run_openscap_remediation_-_ansible_default.erb
+++ b/app/views/job_templates/run_openscap_remediation_-_ansible_default.erb
@@ -31,6 +31,14 @@ require:
       when: is_bootc_host
     - debug: var=out
       when: is_bootc_host
+    - name: Set ansible_pkg_mgr to dnf for image mode hosts (Ansible 2.4 compatibility)
+      set_fact:
+        ansible_pkg_mgr: dnf
+      when: is_bootc_host
+    - name: Set pkg_mgr to dnf for image mode hosts
+      set_fact:
+        ansible_facts: "{{ ansible_facts | combine({'pkg_mgr': 'dnf'}) }}"
+      when: is_bootc_host
 <%= indent(4) { input('tasks') } -%>
 <% if truthy?(input('reboot')) %>
     - name: Reboot the machine


### PR DESCRIPTION
Forces dnf to be the package manager of choice for openscap remediations that modify packages for bootc / image mode machines.

This should be considered a workaround until Ansible fully supports installing packages on image mode machines.

The Ansible 2.5 compatibility line might not be necessary, but I've added it just in case.

To test, try running the job template with package management tasks included on both an image mode machine and a package mode machine.

Note: this will not fix the bootc issue where an earlier `dnf --transient` run causes the usr-overlay to no longer work with un-transient `dnf install` commands. The only way I see around this would be to force the use of `dnf --transient`, which is not possible using the builtin package module. 