### PR TITLE
Fixes #38669 - Fix current_host_details_path usage

### DIFF
--- a/app/helpers/arf_reports_helper.rb
+++ b/app/helpers/arf_reports_helper.rb
@@ -68,7 +68,7 @@ module ArfReportsHelper
       display_link_if_authorized(_('Hosts passing this rule'), hash_for_hosts_path(:search => "passes_xccdf_rule = #{log.source}")),
       display_link_if_authorized(_('Hosts othering this rule'), hash_for_hosts_path(:search => "others_xccdf_rule = #{log.source}")),
     ]
-    if log.result == 'fail' && log.message.fixes.present?
+    if log.report.host && log.result == 'fail' && log.message.fixes.present?
       buttons << link_to_function_if_authorized(_('Remediation'), "showRemediationWizard(#{log.id})", hash_for_show_log_arf_report_path(id: log.report.id))
     end
     action_buttons(buttons)

--- a/app/views/arf_reports/_output.html.erb
+++ b/app/views/arf_reports/_output.html.erb
@@ -37,5 +37,5 @@
 </table>
 <%= react_component 'OpenscapRemediationWizard',
                     { report_id: @arf_report.id,
-                      host: { name: @arf_report.host.name, id: @arf_report.host.id },
+                      host: { name: @arf_report.host&.name, id: @arf_report.host&.id },
                       supported_remediation_snippets: supported_remediation_snippets } %>

--- a/app/views/arf_reports/show.html.erb
+++ b/app/views/arf_reports/show.html.erb
@@ -10,10 +10,14 @@
 
 <%= render 'output', :logs => @arf_report.logs%>
 <%= render 'metrics', :status => @arf_report.status, :metrics => @arf_report.metrics  if @arf_report.logs.any? %>
-
+<% link_to_host = if @arf_report.host
+  link_to(_("Host details"), current_host_details_path(@arf_report.host), :class => "btn btn-default")
+else
+  link_to(_("Host details"), '#', disabled: true, class: "btn btn-default", :"data-original-title" => _("The host was moved or deleted"), rel: "twipsy")
+end %>
 <%= title_actions link_to(_('Back'), :back, :class => "btn btn-default"),
   display_delete_if_authorized(hash_for_arf_report_path(:id => @arf_report), :class=> "btn btn-default"),
-  link_to(_("Host details"), current_host_details_path(:id => @arf_report.host), :class => "btn btn-default"),
+  link_to_host,
   link_to(_("View full report"), show_html_arf_report_path(:id => @arf_report.id), :class => "btn btn-primary"),
   link_to(_("Download XML in bzip"), parse_bzip_arf_report_path(:id => @arf_report.id), :class => "btn btn-default", :data => { :no_turbolink => true }),
   link_to(_("Download HTML"), download_html_arf_report_path(:id => @arf_report.id), :class => "btn btn-default", :data => { :no_turbolink => true })

--- a/lib/foreman_openscap/engine.rb
+++ b/lib/foreman_openscap/engine.rb
@@ -40,7 +40,7 @@ module ForemanOpenscap
     initializer 'foreman_openscap.register_plugin', :before => :finisher_hook do |app|
       app.reloader.to_prepare do
         Foreman::Plugin.register :foreman_openscap do
-          requires_foreman '>= 3.15'
+          requires_foreman '>= 3.16'
           register_gettext
 
           apipie_documented_controllers ["#{ForemanOpenscap::Engine.root}/app/controllers/api/v2/compliance/*.rb"]


### PR DESCRIPTION
TODO:

- [x] - bump requires_foreman? The breaking change introduced in Foreman 3.16, so this is only for 3.16+