### PR TITLE
Fixes #39148 - Take name from host directly

### DIFF
--- a/app/controllers/concerns/foreman_openscap/arf_reports_controller_common_extensions.rb
+++ b/app/controllers/concerns/foreman_openscap/arf_reports_controller_common_extensions.rb
@@ -2,7 +2,7 @@ module ForemanOpenscap
   module ArfReportsControllerCommonExtensions
     extend ActiveSupport::Concern
     def format_filename
-      "#{@arf_report.asset.name}-#{@arf_report.reported_at.to_formatted_s(:number)}"
+      "#{@arf_report.host.name}-#{@arf_report.reported_at.to_formatted_s(:number)}"
     end
   end
 end

--- a/test/functional/arf_reports_controller_test.rb
+++ b/test/functional/arf_reports_controller_test.rb
@@ -34,6 +34,11 @@ class ArfReportsControllerTest < ActionController::TestCase
     arf_report = FactoryBot.create(:arf_report, :host_id => @host.id)
     report_html = File.read("#{ForemanOpenscap::Engine.root}/test/files/arf_report/arf_report.html")
     ForemanOpenscap::ArfReport.any_instance.stubs(:to_html).returns(report_html)
+    refute arf_report.asset.nil?
+    get :download_html, :params => { :id => arf_report.id }, :session => set_session_user
+    assert_equal report_html, @response.body
+
+    arf_report.asset.destroy
     get :download_html, :params => { :id => arf_report.id }, :session => set_session_user
     assert_equal report_html, @response.body
   end


### PR DESCRIPTION
without taking a detour through asset when building a filename when
client tries to download an arf report in html or csv formats.

The arf_report-asset association may not exist if the host gets its
policy from a hostgroup.

Fixes 9b4995a

(cherry picked from commit 1545c0a264d17e12a81afb877810e610569fde5e) (https://github.com/theforeman/foreman_openscap/pull/607)
