### PR TITLE
Fixes #39318 - Allow creating bookmarks for arf_reports controller

### DIFF
--- a/app/validators/concerns/foreman_openscap/bookmark_controller_validator_extensions.rb
+++ b/app/validators/concerns/foreman_openscap/bookmark_controller_validator_extensions.rb
@@ -2,11 +2,10 @@ module ForemanOpenscap
   module BookmarkControllerValidatorExtensions
     module ClassMethods
       def valid_controllers_list
-        super + ActiveRecord::Base.connection
-                                  .tables
-                                  .map(&:to_s)
-                                  .select { |table| table.start_with? 'foreman_openscap_' }
-                                  .map { |table| table.sub('foreman_openscap_', '') }
+        controllers = super
+        controllers + controllers
+                        .select { |controller| controller.start_with?('foreman_openscap_', 'foreman_openscap/') }
+                        .map { |controller| controller.sub(%r{^foreman_openscap[/_]}, '') }
       end
     end
 

--- a/test/unit/concerns/bookmark_controller_validator_extensions_test.rb
+++ b/test/unit/concerns/bookmark_controller_validator_extensions_test.rb
@@ -1,0 +1,16 @@
+require 'test_plugin_helper'
+
+class BookmarkControllerValidatorExtensionsTest < ActiveSupport::TestCase
+  # All controllers including AutoCompleteSearch, except ComplianceDashboardController which is broken anyway
+  [ArfReportsController, ScapContentsController,
+   PoliciesController, TailoringFilesController].each do |controller_class|
+    test "#{controller_class.controller_name} should be a valid bookmark controller" do
+      controller = controller_class.controller_name
+      bookmark = FactoryBot.build_stubbed(:bookmark, :name => "#{controller} bookmark",
+                                                     :controller => controller,
+                                                     :query => 'search query',
+                                                     :public => true)
+      assert bookmark.valid?, "#{controller} should be a valid bookmark controller, errors: #{bookmark.errors.full_messages}"
+    end
+  end
+end


### PR DESCRIPTION
The bookmark controller validator builds its list of valid controllers from database table names and permission resources. Since `ArfReport` uses STI (inheriting from `::Report` and stored in the reports table), there is no `foreman_openscap_arf_reports` table. The previous extension only stripped the `foreman_openscap_` prefix from table names, missing the `foreman_openscap/` prefix that `Permission.resources.map(&:tableize)` produces for namespaced models like `ForemanOpenscap::ArfReport`.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
