### PR TITLE
Fixes #39380 - Update line chart to PatternFly5

### DIFF
--- a/app/assets/javascripts/foreman_openscap/scap_hosts_show.js
+++ b/app/assets/javascripts/foreman_openscap/scap_hosts_show.js
@@ -1,4 +1,0 @@
-$(function() {
-  // Not sure about this ugly hack.
-  $('.col-md-4 .stats-well').height($('.col-md-8 .stats-well').height());
-});

--- a/app/assets/stylesheets/foreman_openscap/scap_breakdown_chart.css
+++ b/app/assets/stylesheets/foreman_openscap/scap_breakdown_chart.css
@@ -1,3 +1,18 @@
+.compliance-host-policy-row {
+  display: flex;
+  flex-wrap: wrap;
+
+  > [class*='col-'] {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .stats-well {
+    flex: 1 1 auto;
+    width: 100%;
+  }
+}
+
 .scap-breakdown-chart {
   margin: 25px auto 12px;
   width: 240px;

--- a/app/views/compliance_hosts/show.html.erb
+++ b/app/views/compliance_hosts/show.html.erb
@@ -1,5 +1,7 @@
-<% javascript 'foreman_openscap/scap_hosts_show' %>
 <% stylesheet 'foreman_openscap/scap_breakdown_chart' %>
+<% content_for(:javascripts) do %>
+  <%= webpacked_plugins_js_for :foreman_openscap %>
+<% end %>
 
 <%= breadcrumbs(:resource_url => api_hosts_path,
                 :resource_filter => "is_compliance_host = true",
@@ -8,7 +10,7 @@
 <% title n_("%s compliance report by policy", "%s compliance reports by policy" , @host.combined_policies.length) % @host.to_label %>
 <% @host.combined_policies.each do |policy| %>
   <h2 class="center-block"><%= _('Policy %s') % policy %></h2>
-  <div class="row">
+  <div class="row compliance-host-policy-row">
     <% data = ForemanOpenscap::HostReportDashboard::Data.new(policy, @host) %>
     <% if data.has_data? %>
     <div class="col-md-4">
@@ -26,7 +28,7 @@
     <div class="col-md-8">
       <div class="stats-well">
         <h4 class="ca"><%= _("%s reports over time") % policy %></h4>
-        <%= react_component('LineChart', host_arf_reports_chart_data(policy.id)) %>
+        <%= react_component('OpenscapLineChart', host_arf_reports_chart_data(policy.id)) %>
       </div>
     </div>
     <% else %>

--- a/lib/foreman_openscap/engine.rb
+++ b/lib/foreman_openscap/engine.rb
@@ -40,7 +40,7 @@ module ForemanOpenscap
     initializer 'foreman_openscap.register_plugin', :before => :finisher_hook do |app|
       app.reloader.to_prepare do
         Foreman::Plugin.register :foreman_openscap do
-          requires_foreman '>= 3.17'
+          requires_foreman '>= 5.0'
           register_gettext
 
           apipie_documented_controllers ["#{ForemanOpenscap::Engine.root}/app/controllers/api/v2/compliance/*.rb"]

--- a/webpack/components/LineChart/LineChart.fixtures.js
+++ b/webpack/components/LineChart/LineChart.fixtures.js
@@ -1,0 +1,28 @@
+export const data = [
+  ['red', [5, 7, 9], '#AA4643'],
+  ['green', [2, 4, 6], '#89A54E'],
+];
+
+const dates = [1557014400000, 1559779200000, 1562457600000];
+
+export const timeseriesData = [
+  ['Passed', [5, 7, 9], '#3f9c35'],
+  ['Failed', [2, 4, 6], '#c9190b'],
+  ['Othered', [1, 0, 2], '#f0ab00'],
+  ['dates', dates, null],
+];
+
+export const emptyTimeseriesData = [
+  ['Passed', [0, 0, 0], '#3f9c35'],
+  ['Failed', [0, 0, 0], '#c9190b'],
+  ['Othered', [0, 0, 0], '#f0ab00'],
+  ['dates', dates, null],
+];
+
+/** Spread-column format used by some Foreman chart fixtures. */
+export const spreadTimeseriesData = [
+  ['Passed', 5, 7, 9, '#3f9c35'],
+  ['Failed', 2, 4, 6, '#c9190b'],
+  ['Othered', 1, 0, 2, '#f0ab00'],
+  ['dates', ...dates, null],
+];

--- a/webpack/components/LineChart/LineChart.scss
+++ b/webpack/components/LineChart/LineChart.scss
@@ -1,0 +1,7 @@
+.line-chart-container {
+  width: 100%;
+  height: 350px;
+  min-width: 200px;
+  min-height: 200px;
+  overflow: visible;
+}

--- a/webpack/components/LineChart/LineChart.test.js
+++ b/webpack/components/LineChart/LineChart.test.js
@@ -22,6 +22,7 @@ import {
   clampChartPadding,
   getTimeseriesXDomain,
   buildLineChartLegendData,
+  formatTooltipValue,
 } from './LineChartHelpers';
 
 jest.unmock('./');
@@ -103,6 +104,18 @@ describe('buildLineChartLegendData', () => {
       symbol: { type: 'eyeSlash' },
     });
     expect(legendData[1].symbol.fill).toBeDefined();
+  });
+});
+
+describe('formatTooltipValue', () => {
+  it('formats rule counts as whole numbers', () => {
+    expect(formatTooltipValue(10)).toBe('10');
+    expect(formatTooltipValue(10.0)).toBe('10');
+    expect(formatTooltipValue(0)).toBe('0');
+  });
+
+  it('rounds non-integer values', () => {
+    expect(formatTooltipValue(6.7)).toBe('7');
   });
 });
 

--- a/webpack/components/LineChart/LineChart.test.js
+++ b/webpack/components/LineChart/LineChart.test.js
@@ -1,0 +1,253 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import {
+  formatAxisTick,
+  formatTooltipTitle,
+  getXAxisTickValues,
+} from 'foremanReact/components/common/charts/helpers/LegendHelpers';
+
+import LineChart from './index';
+import {
+  data,
+  timeseriesData,
+  emptyTimeseriesData,
+  spreadTimeseriesData,
+} from './LineChart.fixtures';
+import {
+  processChartData,
+  hasChartData,
+  sanitizeChartDimension,
+  clampChartPadding,
+  getTimeseriesXDomain,
+  buildLineChartLegendData,
+} from './LineChartHelpers';
+
+jest.unmock('./');
+
+const chartSize = { width: 800, height: 350 };
+
+describe('hasChartData', () => {
+  it('returns false when all series values are zero', () => {
+    expect(hasChartData(emptyTimeseriesData, 'dates')).toBe(false);
+  });
+
+  it('returns true when any series has a non-zero value', () => {
+    expect(hasChartData(timeseriesData, 'dates')).toBe(true);
+  });
+});
+
+describe('chart layout helpers', () => {
+  it('sanitizes invalid chart dimensions', () => {
+    expect(sanitizeChartDimension(Infinity, 350)).toBe(350);
+    expect(sanitizeChartDimension(NaN, 800)).toBe(800);
+    expect(sanitizeChartDimension(500, 800)).toBe(500);
+  });
+
+  it('clamps padding when it exceeds chart size', () => {
+    const padding = clampChartPadding(
+      { top: 50, bottom: 125, left: 300, right: 170 },
+      400,
+      350
+    );
+
+    expect(padding.left + padding.right).toBeLessThan(400);
+    expect(padding.top + padding.bottom).toBeLessThan(350);
+  });
+
+  it('expands degenerate timeseries x domains', () => {
+    const singlePointData = [
+      ['Passed', [5], '#3f9c35'],
+      ['dates', [1557014400000], null],
+    ];
+    const chartData = processChartData(singlePointData, 'dates', 'timeseries');
+    const domain = getTimeseriesXDomain(chartData);
+
+    expect(domain).toHaveLength(2);
+    expect(domain[0].getTime()).toBeLessThan(domain[1].getTime());
+  });
+});
+
+describe('buildLineChartLegendData', () => {
+  it('uses backend series colors for visible legend symbols', () => {
+    const chartData = processChartData(timeseriesData, 'dates', 'timeseries');
+    const legendData = buildLineChartLegendData(chartData, new Set());
+
+    expect(legendData).toEqual([
+      {
+        childName: 'Passed',
+        name: 'Passed',
+        symbol: { type: 'square', fill: '#3f9c35' },
+      },
+      {
+        childName: 'Failed',
+        name: 'Failed',
+        symbol: { type: 'square', fill: '#c9190b' },
+      },
+      {
+        childName: 'Othered',
+        name: 'Othered',
+        symbol: { type: 'square', fill: '#f0ab00' },
+      },
+    ]);
+  });
+
+  it('uses eyeSlash symbol for hidden series', () => {
+    const chartData = processChartData(timeseriesData, 'dates', 'timeseries');
+    const legendData = buildLineChartLegendData(chartData, new Set(['Failed']));
+
+    expect(legendData[1]).toMatchObject({
+      childName: 'Failed',
+      name: 'Failed',
+      symbol: { type: 'eyeSlash' },
+    });
+    expect(legendData[1].symbol.fill).toBeDefined();
+  });
+});
+
+describe('LineChart', () => {
+  it('renders chart with regular data', () => {
+    const { container } = render(
+      <LineChart data={data} config="regular" size={chartSize} />
+    );
+
+    expect(container.querySelector('svg')).toBeInTheDocument();
+  });
+
+  it('renders chart with timeseries data', () => {
+    const { container } = render(
+      <LineChart
+        data={timeseriesData}
+        config="timeseries"
+        xAxisDataLabel="dates"
+        size={chartSize}
+      />
+    );
+
+    expect(container.querySelector('svg')).toBeInTheDocument();
+  });
+
+  it('renders chart with spread-column timeseries data', () => {
+    const { container } = render(
+      <LineChart
+        data={spreadTimeseriesData}
+        config="timeseries"
+        xAxisDataLabel="dates"
+        size={chartSize}
+      />
+    );
+
+    expect(container.querySelector('svg')).toBeInTheDocument();
+  });
+
+  it('renders empty state when no data provided', () => {
+    const { container } = render(<LineChart data={null} />);
+
+    expect(screen.getByText('No data available')).toBeInTheDocument();
+    expect(
+      container.querySelector('.line-chart-container')
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders empty state when all values are zero', () => {
+    const { container } = render(
+      <LineChart
+        data={emptyTimeseriesData}
+        config="timeseries"
+        xAxisDataLabel="dates"
+      />
+    );
+
+    expect(screen.getByText('No data available')).toBeInTheDocument();
+    expect(
+      container.querySelector('.line-chart-container')
+    ).not.toBeInTheDocument();
+  });
+
+  it('displays custom noDataMsg', () => {
+    const customMsg = 'Custom no data message';
+    render(<LineChart data={null} noDataMsg={customMsg} />);
+
+    expect(screen.getByText(customMsg)).toBeInTheDocument();
+  });
+
+  it('renders legend items for each series', () => {
+    const { container } = render(
+      <LineChart
+        data={timeseriesData}
+        config="timeseries"
+        xAxisDataLabel="dates"
+        size={chartSize}
+      />
+    );
+
+    expect(container.textContent).toContain('Passed');
+    expect(container.textContent).toContain('Failed');
+    expect(container.textContent).toContain('Othered');
+  });
+
+  it('legend items are interactive (button role for accessibility)', () => {
+    render(
+      <LineChart
+        data={timeseriesData}
+        config="timeseries"
+        xAxisDataLabel="dates"
+        size={chartSize}
+      />
+    );
+
+    expect(
+      screen.getAllByRole('button', { name: 'Passed' }).length
+    ).toBeGreaterThan(0);
+  });
+
+  it('clicking legend toggles series visibility', () => {
+    const { container } = render(
+      <LineChart
+        data={timeseriesData}
+        config="timeseries"
+        xAxisDataLabel="dates"
+        size={chartSize}
+      />
+    );
+
+    const labels = container.querySelectorAll('.chart-legend-label');
+    expect(labels.length).toBeGreaterThan(0);
+
+    const firstLabel = labels[0];
+    expect(firstLabel).toHaveAttribute('data-hidden', 'false');
+
+    fireEvent.click(firstLabel);
+    expect(firstLabel).toHaveAttribute('data-hidden', 'true');
+
+    fireEvent.click(firstLabel);
+    expect(firstLabel).toHaveAttribute('data-hidden', 'false');
+  });
+
+  it('formats tooltip title for timeseries data points', () => {
+    const chartData = processChartData(timeseriesData, 'dates', 'timeseries');
+    const title = formatTooltipTitle(chartData[0].data[0]);
+
+    expect(title).toMatch(/\d/);
+    expect(title).toContain(',');
+  });
+
+  it('does not show duplicate x-axis labels when multiple data points fall within the same minute', () => {
+    const denseData = [
+      ['Passed', [1, 2, 3], '#3f9c35'],
+      ['Failed', [1, 2, 3], '#c9190b'],
+      ['dates', [1614449768000, 1614449769000, 1614451500000], null],
+    ];
+    const chartData = processChartData(denseData, 'dates', 'timeseries');
+    const tickValues = getXAxisTickValues(chartData, 6);
+
+    expect(tickValues).toBeDefined();
+    expect(tickValues.length).toBeGreaterThan(0);
+
+    const formattedLabels = tickValues.map(t => formatAxisTick(t));
+    const uniqueLabels = [...new Set(formattedLabels)];
+
+    expect(formattedLabels).toHaveLength(uniqueLabels.length);
+  });
+});

--- a/webpack/components/LineChart/LineChartHelpers.js
+++ b/webpack/components/LineChart/LineChartHelpers.js
@@ -1,0 +1,180 @@
+/** Backend sends [label, values, color]; legacy Foreman charts used spread columns. */
+import { chart_color_black_500 as chartColorBlack500 } from '@patternfly/react-tokens';
+
+const getColumnValues = col => {
+  if (Array.isArray(col[1])) return col[1];
+
+  const values = col.slice(1);
+  const last = values[values.length - 1];
+
+  if (
+    values.length > 1 &&
+    (last == null || (typeof last === 'string' && last.startsWith('#')))
+  ) {
+    return values.slice(0, -1);
+  }
+
+  return values;
+};
+
+const getSeriesColor = col => {
+  if (typeof col[2] === 'string' && col[2].startsWith('#')) {
+    return col[2];
+  }
+
+  const last = col[col.length - 1];
+  if (typeof last === 'string' && last.startsWith('#')) {
+    return last;
+  }
+
+  return undefined;
+};
+
+const toMs = val => {
+  const n = Number(val);
+  return n >= 1e12 ? n : n * 1000;
+};
+
+/** Process raw backend data into chart series for PatternFly line charts. */
+export const processChartData = (data, xAxisDataLabel, config) => {
+  if (!data || data.length === 0) return null;
+
+  if (config === 'timeseries') {
+    const timeColumn = data.find(col => col[0] === xAxisDataLabel);
+    if (!timeColumn) return null;
+
+    const xValues = getColumnValues(timeColumn).map(t => toMs(t));
+
+    const series = data
+      .filter(col => col[0] !== xAxisDataLabel)
+      .map(col => {
+        const values = getColumnValues(col);
+        return {
+          name: col[0],
+          color: getSeriesColor(col),
+          data: values.map((value, index) => ({
+            x: new Date(xValues[index]),
+            y: value ?? 0,
+            name: col[0],
+          })),
+        };
+      });
+
+    return series.length > 0 ? series : null;
+  }
+
+  const series = data.map(col => {
+    const values = getColumnValues(col);
+    return {
+      name: col[0],
+      color: getSeriesColor(col),
+      data: values.map((value, index) => ({
+        x: index + 1,
+        y: value ?? 0,
+        name: col[0],
+      })),
+    };
+  });
+
+  return series.some(s => s.data.length > 0) ? series : null;
+};
+
+export const hasChartData = (data, xAxisDataLabel) => {
+  if (!data || data.length === 0) return false;
+
+  return data
+    .filter(col => col[0] !== xAxisDataLabel)
+    .some(col =>
+      getColumnValues(col).some(value => value !== 0 && value != null)
+    );
+};
+
+export const getYTickValues = (chartData, hiddenSeries = new Set()) => {
+  if (!chartData?.length) return undefined;
+
+  let maxY = 0;
+  chartData
+    .filter(chartSeries => !hiddenSeries.has(chartSeries.name))
+    .forEach(chartSeries => {
+      chartSeries.data.forEach(point => {
+        maxY = Math.max(maxY, point.y ?? 0);
+      });
+    });
+
+  if (maxY <= 0) return [0, 0.5, 1.0];
+
+  const step = Math.max(0.1, Math.ceil((maxY / 4) * 10) / 10);
+  return [0, 1, 2, 3, 4, 5].map(i => Math.round(i * step * 10) / 10);
+};
+
+export const sanitizeChartDimension = (value, fallback) => {
+  const n = Number(value);
+  return Number.isFinite(n) && n > 0 ? n : fallback;
+};
+
+/** Prevent padding from exceeding chart size, which breaks Victory scale/range math. */
+export const clampChartPadding = (padding, width, height) => {
+  let { top = 0, bottom = 0, left = 0, right = 0 } = padding;
+
+  const horizontalTotal = left + right;
+  if (horizontalTotal >= width) {
+    const scale = (width * 0.9) / horizontalTotal;
+    left *= scale;
+    right *= scale;
+  }
+
+  const verticalTotal = top + bottom;
+  if (verticalTotal >= height) {
+    const scale = (height * 0.9) / verticalTotal;
+    top *= scale;
+    bottom *= scale;
+  }
+
+  return { top, bottom, left, right };
+};
+
+/** Expand degenerate time domains so Victory can draw valid line paths. */
+export const getTimeseriesXDomain = chartData => {
+  if (!chartData?.[0]?.data?.length) return undefined;
+
+  const times = chartData[0].data.map(point =>
+    point.x instanceof Date ? point.x.getTime() : new Date(point.x).getTime()
+  );
+  const min = Math.min(...times);
+  const max = Math.max(...times);
+
+  if (min === max) {
+    const offset = 12 * 60 * 60 * 1000;
+    return [new Date(min - offset), new Date(max + offset)];
+  }
+
+  return undefined;
+};
+
+/** Legend swatches must use backend series colors, not the default PF theme scale. */
+export const buildLineChartLegendData = (chartData, hiddenSeries) =>
+  chartData.map(series => {
+    const hidden = hiddenSeries.has(series.name);
+
+    if (hidden) {
+      return {
+        childName: series.name,
+        name: series.name,
+        symbol: {
+          type: 'eyeSlash',
+          fill: chartColorBlack500.var,
+        },
+      };
+    }
+
+    return {
+      childName: series.name,
+      name: series.name,
+      ...(series.color && {
+        symbol: {
+          type: 'square',
+          fill: series.color,
+        },
+      }),
+    };
+  });

--- a/webpack/components/LineChart/LineChartHelpers.js
+++ b/webpack/components/LineChart/LineChartHelpers.js
@@ -107,6 +107,16 @@ export const getYTickValues = (chartData, hiddenSeries = new Set()) => {
   return [0, 1, 2, 3, 4, 5].map(i => Math.round(i * step * 10) / 10);
 };
 
+/** Rule counts are whole numbers; avoid decimal formatting in tooltips. */
+export const formatTooltipValue = value => {
+  const num = Number(value);
+  if (!Number.isFinite(num)) return '';
+  if (Math.abs(num) >= 1e21) {
+    return num.toExponential(1);
+  }
+  return String(Math.round(num));
+};
+
 export const sanitizeChartDimension = (value, fallback) => {
   const n = Number(value);
   return Number.isFinite(n) && n > 0 ? n : fallback;

--- a/webpack/components/LineChart/index.js
+++ b/webpack/components/LineChart/index.js
@@ -40,6 +40,7 @@ import {
   clampChartPadding,
   getTimeseriesXDomain,
   buildLineChartLegendData,
+  formatTooltipValue,
 } from './LineChartHelpers';
 import './LineChart.scss';
 
@@ -206,7 +207,7 @@ const LineChart = ({
         containerComponent={
           <CursorVoronoiContainer
             cursorDimension="x"
-            labels={({ datum }) => formatYAxisTick(datum.y)}
+            labels={({ datum }) => formatTooltipValue(datum.y)}
             labelComponent={
               <ChartLegendTooltip
                 legendData={legendData}

--- a/webpack/components/LineChart/index.js
+++ b/webpack/components/LineChart/index.js
@@ -1,0 +1,323 @@
+import React, {
+  useMemo,
+  useRef,
+  useEffect,
+  useLayoutEffect,
+  useState,
+  useCallback,
+} from 'react';
+import PropTypes from 'prop-types';
+import {
+  Chart,
+  ChartAxis,
+  ChartGroup,
+  ChartLine,
+  ChartLegend,
+  ChartLegendTooltip,
+  ChartThemeColor,
+  createContainer,
+} from '@patternfly/react-charts';
+
+import { translate as __ } from 'foremanReact/common/I18n';
+import {
+  formatAxisTick,
+  formatTooltipTitle,
+  formatYAxisTick,
+  getLegendEvents,
+  getSeriesOpacity,
+  getXAxisTickValues,
+  InteractiveLegendLabel,
+  InteractiveLegendSymbol,
+  XAxisTickLabel,
+} from 'foremanReact/components/common/charts/helpers/LegendHelpers';
+import EmptyState from '../EmptyState';
+
+import {
+  processChartData,
+  hasChartData,
+  getYTickValues,
+  sanitizeChartDimension,
+  clampChartPadding,
+  getTimeseriesXDomain,
+  buildLineChartLegendData,
+} from './LineChartHelpers';
+import './LineChart.scss';
+
+const DEFAULT_HEIGHT = 350;
+const DEFAULT_WIDTH = 1000;
+
+/** Match AreaChart padding so angled x-axis tick labels are not clipped. */
+const CHART_PADDING_BASE = { bottom: 125, right: 170, top: 50 };
+
+const getDataClickEvents = onclick => {
+  if (!onclick) return null;
+
+  return {
+    target: 'data',
+    eventHandlers: {
+      onClick: () => [
+        {
+          target: 'data',
+          mutation: props => {
+            if (props.datum?.name) {
+              onclick({ id: props.datum.name });
+            }
+            return null;
+          },
+        },
+      ],
+    },
+  };
+};
+
+const LineChart = ({
+  data,
+  config,
+  noDataMsg,
+  xAxisDataLabel,
+  onclick,
+  id,
+  size,
+  title: _title,
+  unloadData: _unloadData,
+  axisOpts: _axisOpts,
+}) => {
+  const chartData = useMemo(
+    () => processChartData(data, xAxisDataLabel, config),
+    [data, xAxisDataLabel, config]
+  );
+
+  const CursorVoronoiContainer = useMemo(
+    () => createContainer('voronoi', 'cursor'),
+    []
+  );
+
+  const [hiddenSeries, setHiddenSeries] = useState(() => new Set());
+  const [hoveredSeries, setHoveredSeries] = useState(null);
+  const toggleSeries = useCallback(name => {
+    setHiddenSeries(prev => {
+      const next = new Set(prev);
+      if (next.has(name)) next.delete(name);
+      else next.add(name);
+      return next;
+    });
+  }, []);
+
+  const containerRef = useRef(null);
+  const [observedSize, setObservedSize] = useState(null);
+
+  const updateObservedSize = useCallback(() => {
+    const el = containerRef.current;
+    if (!el) return;
+
+    const { width, height } = el.getBoundingClientRect();
+    if (width > 0 && height > 0) {
+      setObservedSize({ width, height });
+    }
+  }, []);
+
+  useLayoutEffect(() => {
+    updateObservedSize();
+  }, [updateObservedSize]);
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el || typeof ResizeObserver === 'undefined') return undefined;
+
+    const observer = new ResizeObserver(() => {
+      updateObservedSize();
+    });
+
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [updateObservedSize]);
+
+  const legendData = useMemo(
+    () => (chartData ? buildLineChartLegendData(chartData, hiddenSeries) : []),
+    [chartData, hiddenSeries]
+  );
+
+  const visibleSeries = useMemo(
+    () => chartData?.filter(series => !hiddenSeries.has(series.name)) ?? [],
+    [chartData, hiddenSeries]
+  );
+
+  const tickValues = useMemo(() => getXAxisTickValues(chartData, 6), [
+    chartData,
+  ]);
+  const yTickValues = useMemo(() => getYTickValues(chartData, hiddenSeries), [
+    chartData,
+    hiddenSeries,
+  ]);
+  const timeseriesXDomain = useMemo(
+    () =>
+      config === 'timeseries' ? getTimeseriesXDomain(chartData) : undefined,
+    [chartData, config]
+  );
+
+  if (!hasChartData(data, xAxisDataLabel) || !chartData) {
+    return (
+      <EmptyState
+        ouiaEmptyStateTitleId="openscap-line-chart-empty-state-title"
+        title={noDataMsg}
+      />
+    );
+  }
+
+  const hasExplicitSize = size?.width > 0 && size?.height > 0;
+  if (!hasExplicitSize && !observedSize) {
+    return <div ref={containerRef} className="line-chart-container" />;
+  }
+
+  const maxTickLabelLen =
+    yTickValues?.length > 0
+      ? Math.max(...yTickValues.map(t => formatYAxisTick(t).length))
+      : formatYAxisTick(0).length;
+  const dynamicLeft = maxTickLabelLen * 8 + 50;
+  const chartHeight = sanitizeChartDimension(
+    size?.height ?? observedSize?.height,
+    DEFAULT_HEIGHT
+  );
+  const chartWidth = sanitizeChartDimension(
+    size?.width ?? observedSize?.width,
+    DEFAULT_WIDTH
+  );
+  const padding = clampChartPadding(
+    {
+      ...CHART_PADDING_BASE,
+      left: dynamicLeft,
+    },
+    chartWidth,
+    chartHeight
+  );
+  const chartName = id || 'line-chart';
+  const legendEvents = getLegendEvents(chartName, toggleSeries);
+  const events = [getDataClickEvents(onclick), legendEvents].filter(Boolean);
+
+  return (
+    <div ref={containerRef} className="line-chart-container">
+      <Chart
+        name={chartName}
+        ariaDesc={__('Line chart')}
+        themeColor={ChartThemeColor.multi}
+        animate={false}
+        domainPadding={{ x: [20, 20], y: [10, 10] }}
+        scale={config === 'timeseries' ? { x: 'time' } : undefined}
+        containerComponent={
+          <CursorVoronoiContainer
+            cursorDimension="x"
+            labels={({ datum }) => formatYAxisTick(datum.y)}
+            labelComponent={
+              <ChartLegendTooltip
+                legendData={legendData}
+                title={formatTooltipTitle}
+              />
+            }
+            mouseFollowTooltips
+            voronoiDimension="x"
+            voronoiPadding={padding}
+            constrainToVisibleArea
+          />
+        }
+        height={chartHeight}
+        width={chartWidth}
+        padding={padding}
+        legendData={legendData}
+        legendOrientation="vertical"
+        legendPosition="right"
+        legendComponent={
+          <ChartLegend
+            dataComponent={
+              <InteractiveLegendSymbol
+                setHoveredSeries={setHoveredSeries}
+                toggleSeries={toggleSeries}
+              />
+            }
+            labelComponent={
+              <InteractiveLegendLabel
+                hiddenSeries={hiddenSeries}
+                hoveredSeries={hoveredSeries}
+                setHoveredSeries={setHoveredSeries}
+                toggleSeries={toggleSeries}
+              />
+            }
+          />
+        }
+        events={events}
+      >
+        <ChartAxis
+          tickValues={config === 'timeseries' ? tickValues : undefined}
+          tickFormat={config === 'timeseries' ? formatAxisTick : undefined}
+          domain={timeseriesXDomain}
+          tickLabelComponent={
+            config === 'timeseries' ? (
+              <XAxisTickLabel yAxisLabelOffset={-12} />
+            ) : (
+              undefined
+            )
+          }
+          style={
+            config === 'timeseries'
+              ? { tickLabels: { angle: -45, verticalAnchor: 'end' } }
+              : undefined
+          }
+        />
+        <ChartAxis
+          dependentAxis
+          showGrid
+          tickValues={yTickValues}
+          tickFormat={formatYAxisTick}
+        />
+        <ChartGroup>
+          {visibleSeries.map(series => (
+            <ChartLine
+              key={series.name}
+              name={series.name}
+              data={series.data}
+              style={{
+                data: {
+                  ...(series.color && { stroke: series.color }),
+                  opacity: getSeriesOpacity(
+                    hoveredSeries && hoveredSeries !== series.name
+                  ),
+                },
+              }}
+            />
+          ))}
+        </ChartGroup>
+      </Chart>
+    </div>
+  );
+};
+
+LineChart.propTypes = {
+  data: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
+  config: PropTypes.oneOf(['regular', 'timeseries']),
+  noDataMsg: PropTypes.string,
+  xAxisDataLabel: PropTypes.string,
+  onclick: PropTypes.func,
+  id: PropTypes.string,
+  size: PropTypes.shape({
+    height: PropTypes.number,
+    width: PropTypes.number,
+  }),
+  // Accepted for compatibility with the legacy Foreman wrapper; unused in PF5.
+  title: PropTypes.object,
+  unloadData: PropTypes.bool,
+  axisOpts: PropTypes.object,
+};
+
+LineChart.defaultProps = {
+  data: undefined,
+  config: 'regular',
+  noDataMsg: __('No data available'),
+  xAxisDataLabel: '',
+  onclick: undefined,
+  id: undefined,
+  size: undefined,
+  title: { type: 'percent' },
+  unloadData: false,
+  axisOpts: {},
+};
+
+export default LineChart;

--- a/webpack/index.js
+++ b/webpack/index.js
@@ -2,10 +2,12 @@ import componentRegistry from 'foremanReact/components/componentRegistry';
 
 import RuleSeverity from './components/RuleSeverity';
 import OpenscapRemediationWizard from './components/OpenscapRemediationWizard';
+import LineChart from './components/LineChart';
 
 const components = [
   { name: 'RuleSeverity', type: RuleSeverity },
   { name: 'OpenscapRemediationWizard', type: OpenscapRemediationWizard },
+  { name: 'OpenscapLineChart', type: LineChart },
 ];
 
 components.forEach(component => {


### PR DESCRIPTION
Fixes: #39380

This PR updates the Line Chart to use PF5 components.

Before:
<img width="1171" height="457" alt="linechart_before" src="https://github.com/user-attachments/assets/2833745f-30ca-46c1-9e2f-5b798b48d410" />

After:
<img width="1055" height="443" alt="Screenshot 2026-06-03 at 11 24 23 AM" src="https://github.com/user-attachments/assets/e9b0a52b-c213-4734-9b7e-a4213e59db3a" />



